### PR TITLE
✨ [FEAT] 재고에 Redis 추가, Write-through 전략 사용

### DIFF
--- a/store-service/src/main/java/com/example/cloudfour/storeservice/config/RedisConfig.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.example.cloudfour.storeservice.config;
+
+import com.example.cloudfour.storeservice.properties.RedisProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(redisProperties.getHost());
+        config.setPort(redisProperties.getPort());
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/collection/document/StoreDocument.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/collection/document/StoreDocument.java
@@ -96,5 +96,10 @@ public class StoreDocument {
     public static class Stock{
         private UUID id;
         private Long quantity;
+
+        public void updateStock(UUID id, Long quantity){
+            this.id = id;
+            this.quantity = quantity;
+        }
     }
 }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/controller/MenuCommonResponseDTO.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/controller/MenuCommonResponseDTO.java
@@ -11,6 +11,7 @@ public class MenuCommonResponseDTO {
     private UUID menuId;
     private String name;
     private Integer price;
+    private Long quantity;
     private String menuPicture;
     private MenuStatus status;
     private String category;

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/converter/MenuConverter.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/converter/MenuConverter.java
@@ -104,6 +104,7 @@ public class MenuConverter {
                 .menuId(menu.getId())
                 .name(menu.getName())
                 .price(menu.getPrice())
+                .quantity(menu.getStock().getQuantity())
                 .menuPicture(menu.getMenuPicture())
                 .status(menu.getMenuStatus())
                 .category(menu.getMenuCategory().getMenuCategoryName())

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/converter/StockConverter.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/converter/StockConverter.java
@@ -3,13 +3,23 @@ package com.example.cloudfour.storeservice.domain.menu.converter;
 import com.example.cloudfour.storeservice.domain.menu.dto.StockResponseDTO;
 import com.example.cloudfour.storeservice.domain.menu.entity.Stock;
 
+import java.util.UUID;
+
 public class StockConverter {
     public static StockResponseDTO toStockResposneDTO(Stock stock){
         return StockResponseDTO.builder()
                 .stockId(stock.getId())
                 .menuId(stock.getMenu().getId())
                 .quantity(stock.getQuantity())
-                .version(stock.getVersion())
+                .build();
+    }
+
+    public static StockResponseDTO CachetoStockResposneDTO(UUID stockId,
+           UUID menuId, Long quantity){
+        return StockResponseDTO.builder()
+                .stockId(stockId)
+                .menuId(menuId)
+                .quantity(quantity)
                 .build();
     }
 }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/dto/StockResponseDTO.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/dto/StockResponseDTO.java
@@ -10,5 +10,4 @@ public class StockResponseDTO {
     private UUID stockId;
     private UUID menuId;
     private Long quantity;
-    private Long version;
 }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/service/StockRedisService.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/service/StockRedisService.java
@@ -1,0 +1,59 @@
+package com.example.cloudfour.storeservice.domain.menu.service;
+
+import com.example.cloudfour.storeservice.util.RedisUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StockRedisService {
+
+    private final RedisUtil redisUtil;
+    private final ObjectMapper objectMapper;
+
+    private static final String STOCK_PREFIX = "stock:";
+    private static final Duration DEFAULT_TTL = Duration.ofHours(1);
+
+    public void cacheStock(UUID stockId, Long quantity) {
+        String key = generateStockKey(stockId);
+        try {
+            redisUtil.setWithTtl(key, quantity.toString(), DEFAULT_TTL);
+            log.debug("Redis에 stock 저장 - stockId: {}, quantity: {}", stockId, quantity);
+        } catch (Exception e) {
+            log.error("Redis에 stock 저장 실패 - stockId: {}", stockId, e);
+        }
+    }
+
+    public Long getStockFromCache(UUID stockId) {
+        String key = generateStockKey(stockId);
+        try {
+            String cachedValue = redisUtil.get(key);
+            if (cachedValue != null) {
+                return Long.valueOf(cachedValue);
+            }
+        } catch (Exception e) {
+            log.error("Redis에 stock 조회 실패 - stockId: {}", stockId, e);
+        }
+        return null;
+    }
+
+    public void updateStockInCache(UUID stockId, Long newQuantity) {
+        String key = generateStockKey(stockId);
+        try {
+            redisUtil.setWithTtl(key, newQuantity.toString(), DEFAULT_TTL);
+            log.debug("Redis에서 stock 업데이트 성공 - stockId: {}, newQuantity: {}", stockId, newQuantity);
+        } catch (Exception e) {
+            log.error("Redis에서 stock 업데이트 실패 - stockId: {}", stockId, e);
+        }
+    }
+
+    private String generateStockKey(UUID stockId) {
+        return STOCK_PREFIX + stockId.toString();
+    }
+}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/service/query/StockQueryService.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/service/query/StockQueryService.java
@@ -10,6 +10,7 @@ import com.example.cloudfour.storeservice.domain.menu.exception.StockErrorCode;
 import com.example.cloudfour.storeservice.domain.menu.exception.StockException;
 import com.example.cloudfour.storeservice.domain.menu.repository.MenuRepository;
 import com.example.cloudfour.storeservice.domain.menu.repository.StockRepository;
+import com.example.cloudfour.storeservice.domain.menu.service.StockRedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,12 +24,22 @@ import java.util.UUID;
 public class StockQueryService {
     private final StockRepository stockRepository;
     private final MenuRepository menuRepository;
+    private final StockRedisService stockRedisService;
 
     @Transactional(readOnly = true)
     public StockResponseDTO getMenuStock(UUID menuId){
         Menu menu = menuRepository.findById(menuId).orElseThrow(()->new MenuException(MenuErrorCode.NOT_FOUND));
         UUID stockId = menu.getStock().getId();
+        Long cachedQuantity = stockRedisService.getStockFromCache(stockId);
+
+        if (cachedQuantity != null) {
+            log.info("Redis에서 재고 찾음 - stockId: {}, quantity: {}", stockId, cachedQuantity);
+            return StockConverter.CachetoStockResposneDTO(stockId,menuId,cachedQuantity);
+        }
+
         Stock stock = stockRepository.findByIdWithOptimisticLock(stockId).orElseThrow(()->new StockException(StockErrorCode.NOT_FOUND));
+        log.info("Redis에서 재고 발견 X, DB에서 찾음 - stockId: {}, quantity: {}", stockId, cachedQuantity);
+        stockRedisService.cacheStock(stockId, stock.getQuantity());
         return StockConverter.toStockResposneDTO(stock);
     }
 }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/properties/RedisProperties.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/properties/RedisProperties.java
@@ -1,0 +1,16 @@
+package com.example.cloudfour.storeservice.properties;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "redis")
+@Getter
+public class RedisProperties {
+    @Value("${spring.data.redis.port}")
+    private int port;
+    @Value("${spring.data.redis.host}")
+    private String host;
+}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/util/RedisUtil.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/util/RedisUtil.java
@@ -1,0 +1,46 @@
+package com.example.cloudfour.storeservice.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void save(String key, String value){
+        redisTemplate.opsForValue().set(key, value);
+    }
+
+    public String get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public boolean setIfAbsent(String key, String value, Duration ttl) {
+        Boolean ok = redisTemplate.opsForValue().setIfAbsent(key, value, ttl);
+        return Boolean.TRUE.equals(ok);
+    }
+
+    public void setWithTtl(String key, String value, Duration ttl) {
+        redisTemplate.opsForValue().set(key, value, ttl);
+    }
+
+    public void expire(String key, Duration ttl) {
+        redisTemplate.expire(key, ttl);
+    }
+
+    public long incrWithTtl(String key, Duration ttl) {
+        Long v = redisTemplate.opsForValue().increment(key);
+        if (v != null && v == 1L) {
+            redisTemplate.expire(key, ttl);
+        }
+        return v == null ? 0L : v;
+    }
+}

--- a/store-service/src/main/resources/application.yml
+++ b/store-service/src/main/resources/application.yml
@@ -36,7 +36,7 @@ spring:
 
   data:
     mongodb:
-    uri: ${MONGO_URI}
+      uri: ${MONGO_URI}
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}

--- a/store-service/src/main/resources/application.yml
+++ b/store-service/src/main/resources/application.yml
@@ -36,7 +36,10 @@ spring:
 
   data:
     mongodb:
-      uri: ${MONGO_URI}
+    uri: ${MONGO_URI}
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
   datasource:
     url: ${LOCAL_DB_URL}
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
## 🔘Part

- [x] Write-through 전략 사용
- [x] stock에 redis 추가
- [x] stock MongoDB 조회 -> Redis 조회로 변경

  <br/>
## ➕ 이슈 링크

- #10 

<br/>

## 🔎 작업 내용

Write-through 전략 사용해서 DB 재고 데이터 실시간급으로 Redis에 동기화
stock에 redis 추가해서 조회할 때 redis의 stock 조회

  <br/>

## 이미지 첨부


<br/>
