### PR TITLE
✨ [FEAT] Passport 인증/인가 적용

### DIFF
--- a/apigateway/build.gradle
+++ b/apigateway/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation "org.springframework.cloud:spring-cloud-starter-loadbalancer"
     runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.104.Final:osx-aarch_64'
     implementation "org.springframework.security:spring-security-oauth2-jose"
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     compileOnly 'org.projectlombok:lombok'

--- a/apigateway/src/main/java/com/example/cloudfour/apigateway/ApiGatewayApplication.java
+++ b/apigateway/src/main/java/com/example/cloudfour/apigateway/ApiGatewayApplication.java
@@ -1,12 +1,13 @@
 package com.example.cloudfour.apigateway;
 
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.SpringApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableFeignClients
 public class ApiGatewayApplication {
     public static void main(String[] args) {
         SpringApplication.run(ApiGatewayApplication.class, args);

--- a/apigateway/src/main/java/com/example/cloudfour/apigateway/client/PassportClient.java
+++ b/apigateway/src/main/java/com/example/cloudfour/apigateway/client/PassportClient.java
@@ -1,0 +1,26 @@
+package com.example.cloudfour.apigateway.client;
+
+import com.example.cloudfour.apigateway.config.FeignConfig;
+import com.example.cloudfour.apigateway.dto.PassportRequestDTO;
+import com.example.cloudfour.apigateway.dto.PassportResponseDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Lazy
+@FeignClient(
+    name = "auth-service",
+    url = "http://localhost:8015",
+    configuration = FeignConfig.class
+)
+public interface PassportClient {
+    
+    @PostMapping("/api/passports")
+    PassportResponseDTO createPassport(@RequestBody PassportRequestDTO request);
+    
+    @GetMapping("/api/passports/{passportId}/validate")
+    Boolean validatePassport(@PathVariable("passportId") String passportId);
+}

--- a/apigateway/src/main/java/com/example/cloudfour/apigateway/config/FeignConfig.java
+++ b/apigateway/src/main/java/com/example/cloudfour/apigateway/config/FeignConfig.java
@@ -1,0 +1,24 @@
+package com.example.cloudfour.apigateway.config;
+
+import feign.Logger;
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+
+
+@Configuration
+public class FeignConfig {
+    
+    @Bean
+    public Logger.Level feignLoggerLevel() {
+        return Logger.Level.BASIC;
+    }
+    
+    @Bean
+    public HttpMessageConverters httpMessageConverters() {
+        HttpMessageConverter<?> jacksonConverter = new MappingJackson2HttpMessageConverter();
+        return new HttpMessageConverters(jacksonConverter);
+    }
+}

--- a/apigateway/src/main/java/com/example/cloudfour/apigateway/dto/PassportRequestDTO.java
+++ b/apigateway/src/main/java/com/example/cloudfour/apigateway/dto/PassportRequestDTO.java
@@ -1,0 +1,17 @@
+package com.example.cloudfour.apigateway.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PassportRequestDTO {
+    private UUID userId;
+    private String role;
+}

--- a/apigateway/src/main/java/com/example/cloudfour/apigateway/dto/PassportRequestDTO.java
+++ b/apigateway/src/main/java/com/example/cloudfour/apigateway/dto/PassportRequestDTO.java
@@ -2,12 +2,12 @@ package com.example.cloudfour.apigateway.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/apigateway/src/main/java/com/example/cloudfour/apigateway/dto/PassportResponseDTO.java
+++ b/apigateway/src/main/java/com/example/cloudfour/apigateway/dto/PassportResponseDTO.java
@@ -1,0 +1,23 @@
+package com.example.cloudfour.apigateway.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PassportResponseDTO {
+    private String passportId;
+    private UUID userId;
+    private String role;
+    private Instant issuedAt;
+    private Instant expiresAt;
+    private String authLevel;
+    private String passportData;
+}

--- a/apigateway/src/main/java/com/example/cloudfour/apigateway/dto/PassportResponseDTO.java
+++ b/apigateway/src/main/java/com/example/cloudfour/apigateway/dto/PassportResponseDTO.java
@@ -2,13 +2,13 @@ package com.example.cloudfour.apigateway.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
 import java.util.UUID;
 
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/apigateway/src/main/java/com/example/cloudfour/apigateway/filter/AuthFilter.java
+++ b/apigateway/src/main/java/com/example/cloudfour/apigateway/filter/AuthFilter.java
@@ -1,6 +1,10 @@
 package com.example.cloudfour.apigateway.filter;
 
+import com.example.cloudfour.apigateway.client.PassportClient;
+import com.example.cloudfour.apigateway.dto.PassportRequestDTO;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -13,16 +17,20 @@ import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
 
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 
 @Slf4j
 @Component
 public class AuthFilter extends AbstractGatewayFilterFactory<AuthFilter.Config> {
 
     private final ReactiveJwtDecoder decoder;
+    private final PassportClient passportClient;
 
-    public AuthFilter(ReactiveJwtDecoder decoder) {
+    @Autowired
+    public AuthFilter(ReactiveJwtDecoder decoder, @Lazy PassportClient passportClient) {
         super(Config.class);
         this.decoder = decoder;
+        this.passportClient = passportClient;
     }
 
     public static class Config {
@@ -43,8 +51,40 @@ public class AuthFilter extends AbstractGatewayFilterFactory<AuthFilter.Config> 
             }
 
             return decoder.decode(token)
-                    .flatMap(jwt -> chain.filter(exchange))
-                    .onErrorResume(err -> unauthorized(exchange, "invalid_token"));
+                    .flatMap(jwt -> {
+                        log.info("JWT 검증 성공, Passport 생성 시작");
+
+                        String userId = jwt.getSubject();
+                        String role = jwt.getClaimAsString("role");
+
+                        if (userId == null) {
+                            return Mono.error(new IllegalArgumentException("JWT에 userId가 없습니다"));
+                        }
+                        if (role == null) {
+                            return Mono.error(new IllegalArgumentException("JWT에 권한이 없습니다"));
+                        }
+
+                        PassportRequestDTO passportRequest = PassportRequestDTO.builder()
+                                .userId(UUID.fromString(userId))
+                                .role(role)
+                                .build();
+
+                        log.info("Passport 생성 요청: userId={}, role={}", userId, role);
+
+                        return Mono.fromCallable(() -> passportClient.createPassport(passportRequest))
+                                .flatMap(passportResponse -> {
+                                    ServerHttpRequest modifiedRequest = request.mutate()
+                                            .header("X-Passport", passportResponse.getPassportData())
+                                            .build();
+
+                                    log.info("Passport 생성 완료, 헤더에 추가: passportId={}", passportResponse.getPassportId());
+                                    return chain.filter(exchange.mutate().request(modifiedRequest).build());
+                                });
+                    })
+                    .onErrorResume(err -> {
+                        log.error("JWT 검증 또는 Passport 생성 실패", err);
+                        return unauthorized(exchange, "invalid_token");
+                    });
         };
     }
 

--- a/auth-service/src/main/java/com/example/cloudfour/authservice/config/PassportConfig.java
+++ b/auth-service/src/main/java/com/example/cloudfour/authservice/config/PassportConfig.java
@@ -1,0 +1,15 @@
+package com.example.cloudfour.authservice.config;
+
+import com.example.cloudfour.modulecommon.util.PassportUtil;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PassportConfig {
+    
+    @Bean
+    public PassportUtil passportUtil() {
+        return new PassportUtil();
+    }
+}
+

--- a/auth-service/src/main/java/com/example/cloudfour/authservice/config/SecurityConfig.java
+++ b/auth-service/src/main/java/com/example/cloudfour/authservice/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.example.cloudfour.authservice.config;
 
-import com.example.cloudfour.modulecommon.filter.JwtClaimsAuthFilter;
+import com.example.cloudfour.modulecommon.passport.filter.InternalPassportFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -13,12 +13,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableMethodSecurity
 public class SecurityConfig {
     @Bean
-    JwtClaimsAuthFilter jwtClaimsAuthFilter() {
-        return new JwtClaimsAuthFilter();
+    InternalPassportFilter internalPassportFilter(com.example.cloudfour.modulecommon.util.PassportUtil passportUtil) {
+        return new InternalPassportFilter(passportUtil);
     }
 
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain securityFilterChain(HttpSecurity http, InternalPassportFilter internalPassportFilter) throws Exception {
         return http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -26,12 +26,13 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/auth/login", "/auth/register/**", "/auth/refresh",
                                 "/auth/email/**", "/.well-known/jwks.json",
+                                "/api/passports/**", "/internal/**",
                                 "/v3/api-docs/**", "/swagger-ui/**", "/actuator/**"
                         ).permitAll()
                         .requestMatchers("/auth/password", "/auth/email/change/**").authenticated()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtClaimsAuthFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(internalPassportFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 }

--- a/auth-service/src/main/java/com/example/cloudfour/authservice/domain/passport/controller/PassportController.java
+++ b/auth-service/src/main/java/com/example/cloudfour/authservice/domain/passport/controller/PassportController.java
@@ -1,0 +1,41 @@
+package com.example.cloudfour.authservice.domain.passport.controller;
+
+import com.example.cloudfour.authservice.domain.passport.dto.PassportRequestDTO;
+import com.example.cloudfour.authservice.domain.passport.dto.PassportResponseDTO;
+import com.example.cloudfour.authservice.domain.passport.service.PassportService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/passports")
+@RequiredArgsConstructor
+public class PassportController {
+    
+    private final PassportService passportService;
+    
+    @PostMapping
+    public ResponseEntity<PassportResponseDTO> createPassport(@RequestBody PassportRequestDTO request) {
+        log.info("Passport 생성 요청: userId={}, role={}", 
+                request.getUserId(), request.getRole());
+        
+        try {
+            PassportResponseDTO passport = passportService.createPassport(request);
+            log.info("Passport 생성 완료: passportId={}", passport.getPassportId());
+            return ResponseEntity.ok(passport);
+        } catch (Exception e) {
+            log.error("Passport 생성 실패: userId={}", request.getUserId(), e);
+            return ResponseEntity.badRequest().build();
+        }
+    }
+    
+    @GetMapping("/{passportId}/validate")
+    public ResponseEntity<Boolean> validatePassport(@PathVariable String passportId) {
+        log.debug("Passport 검증 요청: passportId={}", passportId);
+        
+        boolean isValid = passportService.validatePassport(passportId);
+        return ResponseEntity.ok(isValid);
+    }
+}

--- a/auth-service/src/main/java/com/example/cloudfour/authservice/domain/passport/dto/PassportRequestDTO.java
+++ b/auth-service/src/main/java/com/example/cloudfour/authservice/domain/passport/dto/PassportRequestDTO.java
@@ -1,0 +1,17 @@
+package com.example.cloudfour.authservice.domain.passport.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PassportRequestDTO {
+    private UUID userId;
+    private String role;
+}

--- a/auth-service/src/main/java/com/example/cloudfour/authservice/domain/passport/dto/PassportRequestDTO.java
+++ b/auth-service/src/main/java/com/example/cloudfour/authservice/domain/passport/dto/PassportRequestDTO.java
@@ -2,12 +2,12 @@ package com.example.cloudfour.authservice.domain.passport.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/auth-service/src/main/java/com/example/cloudfour/authservice/domain/passport/dto/PassportResponseDTO.java
+++ b/auth-service/src/main/java/com/example/cloudfour/authservice/domain/passport/dto/PassportResponseDTO.java
@@ -2,13 +2,13 @@ package com.example.cloudfour.authservice.domain.passport.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
 import java.util.UUID;
 
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/auth-service/src/main/java/com/example/cloudfour/authservice/domain/passport/dto/PassportResponseDTO.java
+++ b/auth-service/src/main/java/com/example/cloudfour/authservice/domain/passport/dto/PassportResponseDTO.java
@@ -1,0 +1,23 @@
+package com.example.cloudfour.authservice.domain.passport.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PassportResponseDTO {
+    private String passportId;
+    private UUID userId;
+    private String role;
+    private Instant issuedAt;
+    private Instant expiresAt;
+    private String authLevel;
+    private String passportData;
+}

--- a/auth-service/src/main/java/com/example/cloudfour/authservice/domain/passport/service/PassportService.java
+++ b/auth-service/src/main/java/com/example/cloudfour/authservice/domain/passport/service/PassportService.java
@@ -1,0 +1,136 @@
+package com.example.cloudfour.authservice.domain.passport.service;
+
+import com.example.cloudfour.authservice.domain.passport.dto.PassportRequestDTO;
+import com.example.cloudfour.authservice.domain.passport.dto.PassportResponseDTO;
+import com.example.cloudfour.modulecommon.dto.Passport;
+import com.example.cloudfour.modulecommon.util.PassportUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PassportService {
+    
+    private final PassportUtil passportUtil;
+    private final RedisTemplate<String, String> redisTemplate;
+    
+    private static final String PASSPORT_CACHE_PREFIX = "passport:";
+    private static final long PASSPORT_TTL_MINUTES = 5;
+    
+    public PassportResponseDTO createPassport(PassportRequestDTO request) {
+        try {
+            String existingPassportId = getExistingPassportId(request.getUserId());
+            if (existingPassportId != null) {
+                log.debug("기존 Passport 재사용: passportId={}", existingPassportId);
+                return getPassportFromCache(existingPassportId);
+            }
+        } catch (Exception e) {
+            log.warn("Redis 캐시 확인 실패, 새 Passport 생성: {}", e.getMessage());
+        }
+
+        String passportId = UUID.randomUUID().toString();
+        Instant issuedAt = Instant.now();
+        Instant expiresAt = issuedAt.plusSeconds(PASSPORT_TTL_MINUTES * 60);
+        
+        Passport passport = Passport.builder()
+                .passportId(passportId)
+                .userId(request.getUserId())
+                .role(request.getRole())
+                .issuedAt(issuedAt)
+                .expiresAt(expiresAt)
+                .authLevel(determineAuthLevel(request))
+                .build();
+
+        String passportData = passportUtil.serialize(passport);
+
+        try {
+            String cacheKey = PASSPORT_CACHE_PREFIX + passportId;
+            redisTemplate.opsForValue().set(cacheKey, passportData, PASSPORT_TTL_MINUTES, TimeUnit.MINUTES);
+
+            String userKey = PASSPORT_CACHE_PREFIX + "user:" + request.getUserId();
+            redisTemplate.opsForValue().set(userKey, passportId, PASSPORT_TTL_MINUTES, TimeUnit.MINUTES);
+            
+            log.debug("Passport 캐시 저장 완료: passportId={}", passportId);
+        } catch (Exception e) {
+            log.warn("Redis 캐시 저장 실패, Passport는 생성됨: {}", e.getMessage());
+        }
+        
+        log.info("Passport 생성 및 캐시 저장: passportId={}, userId={}", passportId, request.getUserId());
+        
+        return PassportResponseDTO.builder()
+                .passportId(passportId)
+                .userId(passport.getUserId())
+                .role(passport.getRole())
+                .issuedAt(passport.getIssuedAt())
+                .expiresAt(passport.getExpiresAt())
+                .authLevel(passport.getAuthLevel())
+                .passportData(passportData)
+                .build();
+    }
+    
+    public boolean validatePassport(String passportId) {
+        String cacheKey = PASSPORT_CACHE_PREFIX + passportId;
+        String passportData = redisTemplate.opsForValue().get(cacheKey);
+        
+        if (passportData == null) {
+            log.debug("Passport 캐시에서 찾을 수 없음: passportId={}", passportId);
+            return false;
+        }
+        
+        try {
+            Passport passport = passportUtil.deserialize(passportData);
+            boolean isValid = passport != null && passport.isValid();
+            
+            if (!isValid) {
+                redisTemplate.delete(cacheKey);
+                log.debug("만료된 Passport 제거: passportId={}", passportId);
+            }
+            
+            return isValid;
+        } catch (Exception e) {
+            log.error("Passport 검증 실패: passportId={}", passportId, e);
+            return false;
+        }
+    }
+    
+    private String getExistingPassportId(UUID userId) {
+        String userKey = PASSPORT_CACHE_PREFIX + "user:" + userId;
+        return redisTemplate.opsForValue().get(userKey);
+    }
+    
+    private PassportResponseDTO getPassportFromCache(String passportId) {
+        String cacheKey = PASSPORT_CACHE_PREFIX + passportId;
+        String passportData = redisTemplate.opsForValue().get(cacheKey);
+        
+        if (passportData == null) {
+            return null;
+        }
+        
+        try {
+            Passport passport = passportUtil.deserialize(passportData);
+            return PassportResponseDTO.builder()
+                    .passportId(passportId)
+                    .userId(passport.getUserId())
+                    .role(passport.getRole())
+                    .issuedAt(passport.getIssuedAt())
+                    .expiresAt(passport.getExpiresAt())
+                    .authLevel(passport.getAuthLevel())
+                    .passportData(passportData)
+                    .build();
+        } catch (Exception e) {
+            log.error("캐시된 Passport 파싱 실패: passportId={}", passportId, e);
+            return null;
+        }
+    }
+    
+    private String determineAuthLevel(PassportRequestDTO request) {
+        return "HIGH";
+    }
+}

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -62,11 +62,21 @@ spring:
     default-consumes-media-type: application/json
     default-produces-media-type: application/json
 
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+
 jwt:
-  issuer: http://auth-service
+  issuer: http://localhost:8015
   audience: app
   access-exp-seconds: 900
   refresh-exp-seconds: 1209600
   jwks:
     enabled: true
     key-id: auth-key-1
+    key-store: classpath:keystore.jks
+    key-store-password: password
+    key-alias: auth-key
+
+passport:
+  secret-key: ${PASSPORT_SECRET}

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -67,7 +67,7 @@ spring:
       write-dates-as-timestamps: false
 
 jwt:
-  issuer: http://localhost:8015
+  issuer: http://auth-service
   audience: app
   access-exp-seconds: 900
   refresh-exp-seconds: 1209600

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/config/RestTemplateConfig.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/config/RestTemplateConfig.java
@@ -1,6 +1,7 @@
 package com.example.cloudfour.cartservice.config;
 
 import com.example.cloudfour.modulecommon.error.RestTemplateResponseErrorHandler;
+import com.example.cloudfour.modulecommon.passport.interceptor.PassportInterceptor;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
@@ -12,8 +13,10 @@ public class RestTemplateConfig {
 
     @Bean
     @LoadBalanced
-    public RestTemplate restTemplate(RestTemplateBuilder builder) {
-        return builder.errorHandler(new RestTemplateResponseErrorHandler()).build();
+    public RestTemplate restTemplate(RestTemplateBuilder builder, PassportInterceptor passportInterceptor) {
+        return builder.errorHandler(new RestTemplateResponseErrorHandler())
+                .interceptors(passportInterceptor)
+                .build();
     }
 }
 

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/config/security/SecurityConfig.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/config/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.cloudfour.cartservice.config.security;
 
-import com.example.cloudfour.modulecommon.filter.JwtClaimsAuthFilter;
+import com.example.cloudfour.modulecommon.passport.filter.InternalPassportFilter;
+import com.example.cloudfour.modulecommon.util.PassportUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -14,21 +15,22 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     @Bean
-    JwtClaimsAuthFilter jwtClaimsAuthFilter() {
-        return new JwtClaimsAuthFilter();
+    InternalPassportFilter internalPassportFilter(PassportUtil passportUtil) {
+        return new InternalPassportFilter(passportUtil);
     }
 
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain securityFilterChain(HttpSecurity http, InternalPassportFilter internalPassportFilter) throws Exception {
         return http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/internal/**", "/actuator/**", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
+                        .requestMatchers("/actuator/**", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
+                        .requestMatchers("/internal/**").authenticated()
                         .requestMatchers("/carts/**","/cartItems/**","/orders/**","/profile/**").authenticated()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtClaimsAuthFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(internalPassportFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/controller/CartController.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/controller/CartController.java
@@ -5,7 +5,7 @@ import com.example.cloudfour.cartservice.domain.cart.dto.CartResponseDTO;
 import com.example.cloudfour.cartservice.domain.cart.service.command.CartCommandService;
 import com.example.cloudfour.cartservice.domain.cart.service.query.CartQueryService;
 import com.example.cloudfour.modulecommon.apiPayLoad.CustomResponse;
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -32,35 +32,35 @@ public class CartController {
     private final CartQueryService cartQueryService;
 
     @PostMapping
-    @PreAuthorize("hasRole('ROLE_CUSTOMER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "장바구니 생성", description = "장바구니를 생성합니다. 장바구니 생성에 사용되는 API입니다.")
     public CustomResponse<CartResponseDTO.CartCreateResponseDTO> createCart(
             @Valid @RequestBody CartRequestDTO.CartCreateRequestDTO cartCreateRequestDTO,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        CartResponseDTO.CartCreateResponseDTO cart = cartCommandService.createCart(cartCreateRequestDTO,user);
+        CartResponseDTO.CartCreateResponseDTO cart = cartCommandService.createCart(cartCreateRequestDTO, passport);
         return CustomResponse.onSuccess(HttpStatus.CREATED, cart);
     }
 
     @GetMapping("/{cartId}")
-    @PreAuthorize("hasRole('ROLE_CUSTOMER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "장바구니 조회", description = "장바구니를 조회합니다. 장바구니 조회에 사용되는 API입니다.")
     public CustomResponse<CartResponseDTO.CartDetailResponseDTO> getCart(
             @PathVariable("cartId") UUID cartId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        CartResponseDTO.CartDetailResponseDTO cart = cartQueryService.getCartListById(cartId,user);
+        CartResponseDTO.CartDetailResponseDTO cart = cartQueryService.getCartListById(cartId, passport);
         return CustomResponse.onSuccess(HttpStatus.OK, cart);
     }
 
     @DeleteMapping("/{cartId}")
-    @PreAuthorize("hasRole('ROLE_CUSTOMER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "장바구니 삭제", description = "장바구니를 삭제합니다. 장바구니 삭제에 사용되는 API입니다.")
     public CustomResponse<String> deleteCart(
             @PathVariable("cartId") UUID cartId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ) {
-        cartCommandService.deleteCart(cartId, user);
+        cartCommandService.deleteCart(cartId, passport);
         return CustomResponse.onSuccess(HttpStatus.OK, "장바구니 삭제 완료");
     }
 

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/service/command/CartCommandService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/service/command/CartCommandService.java
@@ -13,7 +13,7 @@ import com.example.cloudfour.cartservice.domain.cartitem.dto.CartItemRequestDTO;
 import com.example.cloudfour.cartservice.domain.cartitem.dto.CartItemResponseDTO;
 import com.example.cloudfour.cartservice.domain.cartitem.service.command.CartItemCommandService;
 import com.example.cloudfour.cartservice.commondto.MenuResponseDTO;
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,13 +34,13 @@ public class CartCommandService {
 
     public CartResponseDTO.CartCreateResponseDTO createCart(
             CartRequestDTO.CartCreateRequestDTO req, 
-            CurrentUser user
+            Passport passport
     ) {
-        validateUser(user);
+        validateUser(passport);
         validateStoreExists(req.getStoreId());
-        validateNoDuplicateCart(user.id(), req.getStoreId());
+        validateNoDuplicateCart(passport.getUserId(), req.getStoreId());
 
-        Cart cart = createCartEntity(user.id(), req.getStoreId());
+        Cart cart = createCartEntity(passport.getUserId(), req.getStoreId());
         Cart savedCart = cartRepository.save(cart);
 
         MenuResponseDTO menu = storeClient.menuById(req.getMenuId());
@@ -48,7 +48,7 @@ public class CartCommandService {
             CartItemConverter.toCartItemAddRequestDTO(req, menu.getPrice());
         
         CartItemResponseDTO.CartItemAddResponseDTO cartItemResponse = 
-            cartItemCommandService.CreateCartItem(cartItemReq, savedCart.getId(), user);
+            cartItemCommandService.CreateCartItem(cartItemReq, savedCart.getId(), passport);
 
         log.info("장바구니 생성 완료 (cartId={}, cartItemId={})", 
             savedCart.getId(), cartItemResponse.getCartItemCommonResponseDTO().getCartItemId());
@@ -60,8 +60,8 @@ public class CartCommandService {
     }
 
     @CacheEvict(value = {"stores", "menus", "menuOptions"}, allEntries = true)
-    public void deleteCart(UUID cartId, CurrentUser user) {
-        validateUser(user);
+    public void deleteCart(UUID cartId, Passport passport) {
+        validateUser(passport);
         
         Cart cart = cartRepository.findById(cartId)
                 .orElseThrow(() -> {
@@ -69,14 +69,14 @@ public class CartCommandService {
                     return new CartException(CartErrorCode.NOT_FOUND);
                 });
 
-        validateCartOwnership(cart, user.id());
+        validateCartOwnership(cart, passport.getUserId());
         
         cartRepository.delete(cart);
         log.info("장바구니 삭제 완료 (cartId={})", cartId);
     }
 
-    private void validateUser(CurrentUser user) {
-        if (user == null || user.id() == null) {
+    private void validateUser(Passport passport) {
+        if (passport == null) {
             log.warn("유효하지 않은 사용자");
             throw new CartException(CartErrorCode.UNAUTHORIZED_ACCESS);
         }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/service/query/CartQueryService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/service/query/CartQueryService.java
@@ -8,7 +8,7 @@ import com.example.cloudfour.cartservice.domain.cart.exception.CartException;
 import com.example.cloudfour.cartservice.domain.cart.repository.CartRepository;
 import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItem;
 import com.example.cloudfour.cartservice.domain.cartitem.repository.CartItemRepository;
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,11 +26,11 @@ public class CartQueryService {
     private final CartRepository cartRepository;
     private final CartItemRepository cartItemRepository;
 
-    public CartResponseDTO.CartDetailResponseDTO getCartListById(UUID cartId, CurrentUser user) {
-        validateUser(user);
+    public CartResponseDTO.CartDetailResponseDTO getCartListById(UUID cartId, Passport passport) {
+        validateUser(passport);
         validateCartId(cartId);
 
-        Cart cart = findCartWithOwnershipValidation(cartId, user.id());
+        Cart cart = findCartWithOwnershipValidation(cartId, passport.getUserId());
         List<CartItem> cartItemsWithOptions = loadCartItemsWithOptions(cartId);
 
         replaceCartItems(cart, cartItemsWithOptions);
@@ -40,8 +40,8 @@ public class CartQueryService {
     }
 
 
-    private void validateUser(CurrentUser user) {
-        if (user == null || user.id() == null) {
+    private void validateUser(Passport passport) {
+        if (passport == null) {
             log.warn("유효하지 않은 사용자");
             throw new CartException(CartErrorCode.UNAUTHORIZED_ACCESS);
         }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/controller/CartItemController.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/controller/CartItemController.java
@@ -6,6 +6,7 @@ import com.example.cloudfour.cartservice.domain.cartitem.service.command.CartIte
 import com.example.cloudfour.cartservice.domain.cartitem.service.query.CartItemQueryService;
 import com.example.cloudfour.modulecommon.apiPayLoad.CustomResponse;
 import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -35,51 +36,51 @@ public class CartItemController {
     private final CartItemQueryService cartItemIdQueryService;
 
     @PostMapping("/{cartId}")
-    @PreAuthorize("hasRole('ROLE_USER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "장바구니 항목 추가", description = "장바구니 항목을 추가합니다. 장바구니 항목 추가에 사용되는 API입니다.")
     public CustomResponse<CartItemResponseDTO.CartItemAddResponseDTO> addCartItem(
             @PathVariable("cartId") UUID cartId,
             @Valid @RequestBody CartItemRequestDTO.CartItemAddRequestDTO cartItemAddRequestDTO,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        CartItemResponseDTO.CartItemAddResponseDTO cartItem = cartItemCommandService.AddCartItem(cartItemAddRequestDTO, cartId, user);
+        CartItemResponseDTO.CartItemAddResponseDTO cartItem = cartItemCommandService.AddCartItem(cartItemAddRequestDTO, cartId, passport);
         return CustomResponse.onSuccess(HttpStatus.CREATED, cartItem);
     }
 
     @GetMapping("/{cartItemId}")
-    @PreAuthorize("hasRole('ROLE_USER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "장바구니 항목 조회", description = "장바구니 항목을 조회합니다. 장바구니 항목 조회에 사용되는 API입니다.")
     public CustomResponse<CartItemResponseDTO.CartItemListResponseDTO> getCartItem(
             @PathVariable("cartItemId") UUID cartItemId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        CartItemResponseDTO.CartItemListResponseDTO cartItem = cartItemIdQueryService.getCartItemById(cartItemId,user);
+        CartItemResponseDTO.CartItemListResponseDTO cartItem = cartItemIdQueryService.getCartItemById(cartItemId, passport);
         return CustomResponse.onSuccess(HttpStatus.OK, cartItem);
     }
 
     @PatchMapping("/{cartItemId}")
-    @PreAuthorize("hasRole('ROLE_USER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "장바구니 항목, 옵션 수정", description = "장바구니 항목, 옵션을 수정합니다. 장바구니 항목, 옵션 수정에 사용되는 API입니다.")
     public CustomResponse<CartItemResponseDTO.CartItemUpdateResponseDTO> updateCartItem(
             @PathVariable("cartItemId") UUID cartItemId,
             @Valid @RequestBody CartItemRequestDTO.CartItemUpdateRequestDTO request,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
         log.info("CartItem 수정 요청 - cartItemId: {}, request: menuOptionIds={}, quantity={}", 
             cartItemId, request.getMenuOptionIds(), request.getQuantity());
         
-        CartItemResponseDTO.CartItemUpdateResponseDTO cartItem = cartItemCommandService.updateCartItem(request, cartItemId, user);
+        CartItemResponseDTO.CartItemUpdateResponseDTO cartItem = cartItemCommandService.updateCartItem(request, cartItemId, passport);
         return CustomResponse.onSuccess(HttpStatus.OK, cartItem);
     }
 
     @DeleteMapping("/{cartItemId}")
-    @PreAuthorize("hasRole('ROLE_USER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "장바구니 항목 삭제", description = "장바구니 항목을 삭제합니다. 장바구니 항목 삭제에 사용되는 API입니다.")
     public CustomResponse<String> deleteCartItem(
             @PathVariable("cartItemId") UUID cartItemId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ) {
-        cartItemCommandService.deleteCartItem(cartItemId, user);
+        cartItemCommandService.deleteCartItem(cartItemId, passport);
         return CustomResponse.onSuccess(HttpStatus.OK, "장바구니 항목 삭제 완료");
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/command/CartItemCommandService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/command/CartItemCommandService.java
@@ -15,7 +15,7 @@ import com.example.cloudfour.cartservice.domain.cartitem.exception.CartItemExcep
 import com.example.cloudfour.cartservice.domain.cartitem.repository.CartItemRepository;
 import com.example.cloudfour.cartservice.commondto.MenuOptionResponseDTO;
 import com.example.cloudfour.cartservice.commondto.MenuResponseDTO;
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,14 +41,14 @@ public class CartItemCommandService {
     public CartItemResponseDTO.CartItemAddResponseDTO CreateCartItem(
             CartItemRequestDTO.CartItemAddRequestDTO req,
             UUID cartId,
-            CurrentUser user
+            Passport passport
     ) {
-        if (user == null) {
+        if (passport == null) {
             log.warn("장바구니 아이템 추가 권한 없음");
             throw new CartItemException(CartItemErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        Cart cart = cartRepository.findByIdAndUser(cartId, user.id())
+        Cart cart = cartRepository.findByIdAndUser(cartId, passport.getUserId())
                 .orElseThrow(() -> {
                     log.warn("존재하지 않는 장바구니");
                     return new CartException(CartErrorCode.NOT_FOUND);
@@ -100,14 +100,14 @@ public class CartItemCommandService {
     public CartItemResponseDTO.CartItemAddResponseDTO AddCartItem(
             CartItemRequestDTO.CartItemAddRequestDTO req,
             UUID cartId,
-            CurrentUser user
+            Passport passport
     ) {
-        if (user == null) {
+        if (passport == null) {
             log.warn("장바구니 아이템 생성 권한 없음");
             throw new CartItemException(CartItemErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        Cart cart = cartRepository.findByIdAndUser(cartId, user.id())
+        Cart cart = cartRepository.findByIdAndUser(cartId, passport.getUserId())
                 .orElseThrow(() -> {
                     log.warn("존재하지 않는 장바구니");
                     return new CartException(CartErrorCode.NOT_FOUND);
@@ -161,14 +161,14 @@ public class CartItemCommandService {
     public CartItemResponseDTO.CartItemUpdateResponseDTO updateCartItem(
             CartItemRequestDTO.CartItemUpdateRequestDTO req,
             UUID cartItemId,
-            CurrentUser user
+            Passport passport
     ) {
         CartItem cartItem = cartItemRepository.findById(cartItemId).orElseThrow(() -> {
             log.warn("존재하지 않는 장바구니 아이템");
             return new CartItemException(CartItemErrorCode.NOT_FOUND);
         });
 
-        if (user == null || !cartItemRepository.existsByCartItemAndUser(cartItemId, user.id())) {
+        if (passport == null || !cartItemRepository.existsByCartItemAndUser(cartItemId, passport.getUserId())) {
             log.warn("장바구니 아이템 수정 권한 없음");
             throw new CartItemException(CartItemErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -205,7 +205,7 @@ public class CartItemCommandService {
         return CartItemConverter.toCartItemUpdateResponseDTO(loaded);
     }
 
-    public void deleteCartItem(UUID cartItemId, CurrentUser user) {
+    public void deleteCartItem(UUID cartItemId, Passport passport) {
         CartItem cartItem = cartItemRepository.findById(cartItemId).orElseThrow(() -> {
             log.warn("존재하지 않는 장바구니 아이템");
             return new CartItemException(CartItemErrorCode.NOT_FOUND);
@@ -216,7 +216,7 @@ public class CartItemCommandService {
             return new CartException(CartErrorCode.NOT_FOUND);
         });
 
-        if (user == null || !cartItemRepository.existsByCartItemAndUser(cartItemId, user.id())) {
+        if (passport == null || !cartItemRepository.existsByCartItemAndUser(cartItemId, passport.getUserId())) {
             log.warn("장바구니 아이템 삭제 권한 없음");
             throw new CartItemException(CartItemErrorCode.UNAUTHORIZED_ACCESS);
         }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/query/CartItemQueryService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/query/CartItemQueryService.java
@@ -6,7 +6,7 @@ import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItem;
 import com.example.cloudfour.cartservice.domain.cartitem.exception.CartItemErrorCode;
 import com.example.cloudfour.cartservice.domain.cartitem.exception.CartItemException;
 import com.example.cloudfour.cartservice.domain.cartitem.repository.CartItemRepository;
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,10 +22,10 @@ public class CartItemQueryService {
 
     private final CartItemRepository cartItemRepository;
 
-    public CartItemResponseDTO.CartItemListResponseDTO getCartItemById(UUID cartItemId, CurrentUser user) {
-        validateUser(user);
+    public CartItemResponseDTO.CartItemListResponseDTO getCartItemById(UUID cartItemId, Passport passport) {
+        validateUser(passport);
         validateCartItemId(cartItemId);
-        validateCartItemOwnership(cartItemId, user.id());
+        validateCartItemOwnership(cartItemId, passport.getUserId());
 
         CartItem cartItem = findCartItemWithOptions(cartItemId);
         
@@ -33,8 +33,8 @@ public class CartItemQueryService {
         return CartItemConverter.toCartItemListResponseDTO(cartItem);
     }
 
-    private void validateUser(CurrentUser user) {
-        if (user == null || user.id() == null) {
+    private void validateUser(Passport passport) {
+        if (passport == null) {
             log.warn("유효하지 않은 사용자");
             throw new CartItemException(CartItemErrorCode.UNAUTHORIZED_ACCESS);
         }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/controller/OrderController.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/controller/OrderController.java
@@ -6,7 +6,7 @@ import com.example.cloudfour.cartservice.domain.order.dto.OrderResponseDTO;
 import com.example.cloudfour.cartservice.domain.order.service.command.OrderCommandService;
 import com.example.cloudfour.cartservice.domain.order.service.query.OrderQueryService;
 import com.example.cloudfour.modulecommon.apiPayLoad.CustomResponse;
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,50 +37,50 @@ public class OrderController {
     private final OrderQueryService orderQueryService;
 
     @PostMapping("/{cartId}")
-    @PreAuthorize("hasRole('ROLE_USER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "주문 생성", description = "주문을 생성합니다. 주문 생성에 사용되는 API입니다.")
     public CustomResponse<OrderResponseDTO.OrderCreateResponseDTO> createOrder(
             @PathVariable("cartId") UUID cartId,
             @Valid @RequestBody OrderRequestDTO.OrderCreateRequestDTO orderCreateRequestDTO,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        OrderResponseDTO.OrderCreateResponseDTO order = orderCommandService.createOrder(orderCreateRequestDTO,cartId,user);
+        OrderResponseDTO.OrderCreateResponseDTO order = orderCommandService.createOrder(orderCreateRequestDTO,cartId,passport);
         return CustomResponse.onSuccess(HttpStatus.CREATED, order);
     }
 
     @GetMapping("/{orderId}")
-    @PreAuthorize("hasRole('ROLE_USER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "주문 상세 조회", description = "주문을 상세 조회합니다. 주문 상세 조회에 사용되는 API입니다.")
     public CustomResponse<OrderResponseDTO.OrderDetailResponseDTO> getOrder(
             @PathVariable("orderId") UUID orderId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        OrderResponseDTO.OrderDetailResponseDTO order = orderQueryService.getOrderById(orderId,user);
+        OrderResponseDTO.OrderDetailResponseDTO order = orderQueryService.getOrderById(orderId,passport);
         return CustomResponse.onSuccess(HttpStatus.OK, order);
     }
 
     @GetMapping("/{orderItemId}")
-    @PreAuthorize("hasRole('ROLE_USER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "주문 아이템 상세 조회", description = "주문 아이템을 상세 조회합니다. 주문 아이템 상세 조회에 사용되는 API입니다.")
     public CustomResponse<OrderItemResponseDTO.OrderItemListResponseDTO> getOrderItem(
             @PathVariable("orderItemId") UUID orderItemId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        OrderItemResponseDTO.OrderItemListResponseDTO orderItem = orderQueryService.getOrderItemById(orderItemId,user);
+        OrderItemResponseDTO.OrderItemListResponseDTO orderItem = orderQueryService.getOrderItemById(orderItemId,passport);
         return CustomResponse.onSuccess(HttpStatus.OK, orderItem);
     }
 
     @GetMapping("/me")
-    @PreAuthorize("hasRole('ROLE_USER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "내 주문 내역 조회", description = "내 주문 내역을 조회합니다. 내 주문 내역 조회에 사용되는 API입니다.")
     @Parameter(name = "cursor", description = "데이터가 시작하는 부분을 표시합니다")
     @Parameter(name = "size", description = "size만큼 데이터를 가져옵니다.")
     public CustomResponse<OrderResponseDTO.OrderUserListResponseDTO> getMyOrder(
-            @AuthenticationPrincipal CurrentUser user,
+            @AuthenticationPrincipal Passport passport,
             @RequestParam(name = "cursor", required = false) LocalDateTime cursor,
             @RequestParam(name = "size", defaultValue = "10") Integer size
     ){
-        OrderResponseDTO.OrderUserListResponseDTO order = orderQueryService.getOrderListByUser(user,cursor,size);
+        OrderResponseDTO.OrderUserListResponseDTO order = orderQueryService.getOrderListByUser(passport,cursor,size);
         return CustomResponse.onSuccess(HttpStatus.OK, order);
     }
 
@@ -91,11 +91,11 @@ public class OrderController {
     @Parameter(name = "size", description = "size만큼 데이터를 가져옵니다.")
     public CustomResponse<OrderResponseDTO.OrderStoreListResponseDTO> getStoreOrder(
             @PathVariable("storeId") UUID storeId,
-            @AuthenticationPrincipal CurrentUser user,
+            @AuthenticationPrincipal Passport passport,
             @RequestParam(name = "cursor", required = false) LocalDateTime cursor,
             @RequestParam(name = "size", defaultValue = "10") Integer size
     ){
-        OrderResponseDTO.OrderStoreListResponseDTO order = orderQueryService.getOrderListByStore(storeId,cursor,size,user);
+        OrderResponseDTO.OrderStoreListResponseDTO order = orderQueryService.getOrderListByStore(storeId,cursor,size,passport);
         return CustomResponse.onSuccess(HttpStatus.OK, order);
     }
 
@@ -105,9 +105,9 @@ public class OrderController {
     public CustomResponse<OrderResponseDTO.OrderUpdateResponseDTO>  updateOrderStatus(
             @Valid @RequestBody OrderRequestDTO.OrderUpdateRequestDTO orderUpdateRequestDTO,
             @PathVariable("orderId") UUID orderId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        OrderResponseDTO.OrderUpdateResponseDTO order = orderCommandService.updateOrder(orderUpdateRequestDTO,orderId,user);
+        OrderResponseDTO.OrderUpdateResponseDTO order = orderCommandService.updateOrder(orderUpdateRequestDTO,orderId,passport);
         return CustomResponse.onSuccess(HttpStatus.OK, order);
     }
 
@@ -116,9 +116,9 @@ public class OrderController {
     @Operation(summary = "주문 취소", description = "주문을 취소합니다. 주문 취소에 사용되는 API입니다.")
     public CustomResponse<String>  deleteOrder(
             @PathVariable("orderId") UUID orderId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        orderCommandService.deleteOrder(orderId,user);
+        orderCommandService.deleteOrder(orderId,passport);
         return CustomResponse.onSuccess(HttpStatus.OK, "주문 취소 완료.");
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/service/command/OrderCommandService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/service/command/OrderCommandService.java
@@ -26,7 +26,7 @@ import com.example.cloudfour.cartservice.domain.order.repository.OrderItemOption
 import com.example.cloudfour.cartservice.domain.order.repository.OrderItemRepository;
 import com.example.cloudfour.cartservice.domain.order.repository.OrderRepository;
 import com.example.cloudfour.cartservice.service.OrderEventPublishService;
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,13 +53,13 @@ public class OrderCommandService {
     public OrderResponseDTO.OrderCreateResponseDTO createOrder(
             OrderRequestDTO.OrderCreateRequestDTO req, 
             UUID cartId, 
-            CurrentUser user
+            Passport passport
     ) {
-        validateUser(user);
+        validateUser(passport);
         validateCartId(cartId);
 
-        Cart cart = findCartWithOwnershipValidation(cartId, user.id());
-        UserAddressResponseDTO userAddress = fetchUserAddress(user.id());
+        Cart cart = findCartWithOwnershipValidation(cartId, passport.getUserId());
+        UserAddressResponseDTO userAddress = fetchUserAddress(passport.getUserId());
         validateStoreExists(cart.getStore());
         validateCartItemsNotEmpty(cart.getCartItems());
 
@@ -67,7 +67,7 @@ public class OrderCommandService {
 
         int totalPrice = calculateTotalPrice(cart.getCartItems());
         
-        Order order = createOrderEntity(req, totalPrice, userAddress.getAddress(), cart.getStore(), user.id());
+        Order order = createOrderEntity(req, totalPrice, userAddress.getAddress(), cart.getStore(), passport.getUserId());
         orderRepository.save(order);
         
         List<OrderItem> orderItems = createOrderItems(cart.getCartItems(), order);
@@ -85,12 +85,12 @@ public class OrderCommandService {
 
     public OrderResponseDTO.OrderUpdateResponseDTO updateOrder(
             OrderRequestDTO.OrderUpdateRequestDTO req, 
-            UUID orderId, 
-            CurrentUser user
+            UUID orderId,
+            Passport passport
     ) {
-        validateUser(user);
+        validateUser(passport);
         validateOrderId(orderId);
-        validateOrderOwnership(orderId, user.id());
+        validateOrderOwnership(orderId, passport.getUserId());
 
         Order order = findOrderById(orderId);
         OrderStatus prevStatus = order.getStatus();
@@ -110,10 +110,10 @@ public class OrderCommandService {
         return OrderConverter.toOrderUpdateResponseDTO(order, prevStatus);
     }
 
-    public void deleteOrder(UUID orderId, CurrentUser user) {
-        validateUser(user);
+    public void deleteOrder(UUID orderId, Passport passport) {
+        validateUser(passport);
         validateOrderId(orderId);
-        validateOrderOwnership(orderId, user.id());
+        validateOrderOwnership(orderId, passport.getUserId());
 
         Order order = findOrderById(orderId);
 
@@ -168,8 +168,8 @@ public class OrderCommandService {
             orderId, prevStatus, newOrderStatus);
     }
 
-    private void validateUser(CurrentUser user) {
-        if (user == null || user.id() == null) {
+    private void validateUser(Passport passport) {
+        if (passport == null || passport.getUserId() == null) {
             log.warn("유효하지 않은 사용자");
             throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
         }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/service/query/OrderQueryService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/service/query/OrderQueryService.java
@@ -16,7 +16,7 @@ import com.example.cloudfour.cartservice.domain.order.exception.OrderItemErrorCo
 import com.example.cloudfour.cartservice.domain.order.exception.OrderItemException;
 import com.example.cloudfour.cartservice.domain.order.repository.OrderItemRepository;
 import com.example.cloudfour.cartservice.domain.order.repository.OrderRepository;
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -42,10 +42,10 @@ public class OrderQueryService {
 
     private static final LocalDateTime FIRST_CURSOR = LocalDateTime.now().plusDays(1);
 
-    public OrderResponseDTO.OrderDetailResponseDTO getOrderById(UUID orderId, CurrentUser user) {
-        validateUser(user);
+    public OrderResponseDTO.OrderDetailResponseDTO getOrderById(UUID orderId, Passport passport) {
+        validateUser(passport);
         validateOrderId(orderId);
-        validateOrderOwnership(orderId, user.id());
+        validateOrderOwnership(orderId, passport.getUserId());
 
         Order order = findOrderById(orderId);
         List<OrderItem> orderItems = orderItemRepository.findByOrderId(orderId);
@@ -58,12 +58,12 @@ public class OrderQueryService {
         return OrderConverter.toOrderDetailResponseDTO(order, orderItemDtos, store.getName());
     }
 
-    public OrderItemResponseDTO.OrderItemListResponseDTO getOrderItemById(UUID orderItemId, CurrentUser user){
+    public OrderItemResponseDTO.OrderItemListResponseDTO getOrderItemById(UUID orderItemId, Passport passport){
         OrderItem orderItem = orderItemRepository.findById(orderItemId).orElseThrow(()->{
             log.warn("존재하지 않는 주문 아이템");
             return new OrderItemException(OrderItemErrorCode.NOT_FOUND);
         });
-        if(user == null || orderItemRepository.existsByUserId(orderItem.getId(),user.id())){
+        if(passport == null || orderItemRepository.existsByUserId(orderItem.getId(), passport.getUserId())){
             log.warn("주문 아이템 조회 권한 없음");
             throw new OrderItemException(OrderItemErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -72,8 +72,8 @@ public class OrderQueryService {
         return OrderItemConverter.toOrderItemClassListDTO(orderItem);
     }
 
-    public OrderResponseDTO.OrderUserListResponseDTO getOrderListByUser(CurrentUser user, LocalDateTime cursor, Integer size) {
-        if(user == null){
+    public OrderResponseDTO.OrderUserListResponseDTO getOrderListByUser(Passport passport, LocalDateTime cursor, Integer size) {
+        if(passport == null){
             log.warn("사용자 주문 목록 조회 권한 없음");
             throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -82,7 +82,7 @@ public class OrderQueryService {
             cursor = FIRST_CURSOR;
         }
         Pageable pageable = PageRequest.of(0, size);
-        Slice<Order> orders = orderRepository.findAllByUserId(user.id(), cursor, pageable);
+        Slice<Order> orders = orderRepository.findAllByUserId(passport.getUserId(), cursor, pageable);
         if(orders.isEmpty()) {
             log.warn("존재하지 않는 주문");
             throw new OrderException(OrderErrorCode.NOT_FOUND);
@@ -100,9 +100,9 @@ public class OrderQueryService {
         return OrderConverter.toOrderUserListResponseDTO(orderUserResponseDTOS,orders.hasNext(),next_cursor);
     }
 
-    public OrderResponseDTO.OrderStoreListResponseDTO getOrderListByStore(UUID storeId, LocalDateTime cursor, Integer size, CurrentUser user) {
+    public OrderResponseDTO.OrderStoreListResponseDTO getOrderListByStore(UUID storeId, LocalDateTime cursor, Integer size, Passport passport) {
         StoreResponseDTO store = storeClient.storeById(storeId);
-        if(user == null || store.getUserId() != user.id()) {
+        if(passport == null || store.getUserId() != passport.getUserId()) {
             log.info("가게 주문 목록 조회 권한 없음");
             throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -128,8 +128,8 @@ public class OrderQueryService {
         return OrderConverter.toOrderStoreListResponseDTO(orderStoreResponseDTOS, orders.hasNext(), next_cursor);
     }
 
-    private void validateUser(CurrentUser user) {
-        if (user == null || user.id() == null) {
+    private void validateUser(Passport passport) {
+        if (passport == null || passport.getUserId() == null) {
             log.warn("유효하지 않은 사용자");
             throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
         }

--- a/cart-service/src/main/resources/application.yml
+++ b/cart-service/src/main/resources/application.yml
@@ -49,6 +49,9 @@ spring:
     config:
       enabled: false
 
+passport:
+  secret-key: ${PASSPORT_SECRET}
+
   springdoc:
     api-docs:
       version: openapi_3_1

--- a/module-common/src/main/java/com/example/cloudfour/modulecommon/dto/Passport.java
+++ b/module-common/src/main/java/com/example/cloudfour/modulecommon/dto/Passport.java
@@ -2,7 +2,7 @@ package com.example.cloudfour.modulecommon.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.Instant;
 import java.util.UUID;
 
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/module-common/src/main/java/com/example/cloudfour/modulecommon/dto/Passport.java
+++ b/module-common/src/main/java/com/example/cloudfour/modulecommon/dto/Passport.java
@@ -1,0 +1,40 @@
+package com.example.cloudfour.modulecommon.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Passport {
+    private String passportId;
+    private UUID userId;
+    private String role;
+    private Instant issuedAt;
+    private Instant expiresAt;
+    private String authLevel;
+    
+    @JsonIgnore
+    public boolean isValid() {
+        return passportId != null && 
+               userId != null && 
+               role != null && 
+               issuedAt != null && 
+               expiresAt != null &&
+               Instant.now().isBefore(expiresAt);
+    }
+
+    @JsonIgnore
+    public boolean isHighAuthLevel() {
+        return "HIGH".equals(authLevel);
+    }
+}

--- a/module-common/src/main/java/com/example/cloudfour/modulecommon/passport/annotation/RequireHighAuthLevel.java
+++ b/module-common/src/main/java/com/example/cloudfour/modulecommon/passport/annotation/RequireHighAuthLevel.java
@@ -1,0 +1,11 @@
+package com.example.cloudfour.modulecommon.passport.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequireHighAuthLevel {
+}

--- a/module-common/src/main/java/com/example/cloudfour/modulecommon/passport/aspect/PassportAuthLevelAspect.java
+++ b/module-common/src/main/java/com/example/cloudfour/modulecommon/passport/aspect/PassportAuthLevelAspect.java
@@ -1,0 +1,43 @@
+package com.example.cloudfour.modulecommon.passport.aspect;
+
+import com.example.cloudfour.modulecommon.dto.Passport;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+
+@Slf4j
+@Aspect
+@Component
+public class PassportAuthLevelAspect {
+    
+    @Around("@annotation(com.example.cloudfour.modulecommon.passport.annotation.RequireHighAuthLevel)")
+    public Object checkHighAuthLevel(ProceedingJoinPoint joinPoint) throws Throwable {
+        Passport passport = getPassportFromParameters(joinPoint.getArgs());
+        
+        if (passport == null) {
+            log.warn("Passport를 찾을 수 없습니다");
+            throw new HttpClientErrorException(HttpStatus.UNAUTHORIZED, "Passport를 찾을 수 없습니다");
+        }
+        
+        if (!passport.isHighAuthLevel()) {
+            log.warn("높은 인증 레벨이 필요합니다: current={}", passport.getAuthLevel());
+            throw new HttpClientErrorException(HttpStatus.FORBIDDEN, "높은 인증 레벨이 필요합니다");
+        }
+        
+        log.debug("높은 인증 레벨 검증 성공: authLevel={}", passport.getAuthLevel());
+        return joinPoint.proceed();
+    }
+    
+    private Passport getPassportFromParameters(Object[] args) {
+        for (Object arg : args) {
+            if (arg instanceof Passport) {
+                return (Passport) arg;
+            }
+        }
+        return null;
+    }
+}

--- a/module-common/src/main/java/com/example/cloudfour/modulecommon/passport/filter/InternalPassportFilter.java
+++ b/module-common/src/main/java/com/example/cloudfour/modulecommon/passport/filter/InternalPassportFilter.java
@@ -1,0 +1,63 @@
+package com.example.cloudfour.modulecommon.passport.filter;
+
+import com.example.cloudfour.modulecommon.dto.Passport;
+import com.example.cloudfour.modulecommon.passport.security.PassportAuthenticationToken;
+import com.example.cloudfour.modulecommon.util.PassportUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collection;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InternalPassportFilter extends OncePerRequestFilter {
+    
+    private final PassportUtil passportUtil;
+    
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        
+        String passportHeader = request.getHeader("X-Passport");
+        
+        if (StringUtils.hasText(passportHeader)) {
+            try {
+                Passport passport = passportUtil.deserialize(passportHeader);
+                
+                if (passport != null && passport.isValid()) {
+                    Collection<? extends GrantedAuthority> authorities = 
+                            (passport.getRole() != null && !passport.getRole().isBlank())
+                                    ? AuthorityUtils.createAuthorityList(passport.getRole())
+                                    : AuthorityUtils.NO_AUTHORITIES;
+
+                    var authentication = new PassportAuthenticationToken(passport, authorities);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    
+                    log.debug("Passport 인증 성공: userId={}, role={}, authLevel={}", 
+                            passport.getUserId(), passport.getRole(), passport.getAuthLevel());
+                } else {
+                    log.warn("유효하지 않은 Passport: {}", passportHeader);
+                }
+            } catch (Exception e) {
+                log.error("Passport 파싱 실패: {}", passportHeader, e);
+            }
+        } else {
+            log.debug("X-Passport 헤더가 없습니다");
+        }
+        
+        chain.doFilter(request, response);
+    }
+}
+

--- a/module-common/src/main/java/com/example/cloudfour/modulecommon/passport/interceptor/PassportInterceptor.java
+++ b/module-common/src/main/java/com/example/cloudfour/modulecommon/passport/interceptor/PassportInterceptor.java
@@ -1,0 +1,49 @@
+package com.example.cloudfour.modulecommon.passport.interceptor;
+
+import com.example.cloudfour.modulecommon.dto.Passport;
+import com.example.cloudfour.modulecommon.util.PassportUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PassportInterceptor implements ClientHttpRequestInterceptor {
+    
+    private final PassportUtil passportUtil;
+    
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) 
+            throws IOException {
+
+        String existingPassport = request.getHeaders().getFirst("X-Passport");
+        if (existingPassport != null) {
+            log.debug("기존 Passport를 내부 통신에 전달: {}", existingPassport);
+            return execution.execute(request, body);
+        }
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof Passport) {
+            Passport currentPassport = (Passport) authentication.getPrincipal();
+
+            String passportData = passportUtil.serialize(currentPassport);
+            request.getHeaders().add("X-Passport", passportData);
+            
+            log.debug("현재 사용자 Passport를 내부 통신에 전달: userId={}, role={}", 
+                    currentPassport.getUserId(), currentPassport.getRole());
+            return execution.execute(request, body);
+        }
+
+        log.error("내부 통신 시 Passport가 필요합니다");
+        throw new RuntimeException("내부 통신 시 Passport가 필요합니다");
+    }
+}

--- a/module-common/src/main/java/com/example/cloudfour/modulecommon/passport/security/PassportAuthenticationToken.java
+++ b/module-common/src/main/java/com/example/cloudfour/modulecommon/passport/security/PassportAuthenticationToken.java
@@ -1,4 +1,4 @@
-package com.example.cloudfour.modulecommon.security;
+package com.example.cloudfour.modulecommon.passport.security;
 
 import com.example.cloudfour.modulecommon.dto.Passport;
 import org.springframework.security.authentication.AbstractAuthenticationToken;

--- a/module-common/src/main/java/com/example/cloudfour/modulecommon/security/PassportAuthenticationToken.java
+++ b/module-common/src/main/java/com/example/cloudfour/modulecommon/security/PassportAuthenticationToken.java
@@ -1,0 +1,37 @@
+package com.example.cloudfour.modulecommon.security;
+
+import com.example.cloudfour.modulecommon.dto.Passport;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class PassportAuthenticationToken extends AbstractAuthenticationToken {
+    
+    private final Passport passport;
+    
+    public PassportAuthenticationToken(Passport passport, Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.passport = passport;
+        setAuthenticated(true);
+    }
+    
+    @Override
+    public Object getCredentials() {
+        return passport;
+    }
+
+    @Override
+    public String getName() {
+        return passport != null ? passport.getUserId().toString() : null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return passport;
+    }
+    
+    public Passport getPassport() {
+        return passport;
+    }
+}

--- a/module-common/src/main/java/com/example/cloudfour/modulecommon/util/PassportUtil.java
+++ b/module-common/src/main/java/com/example/cloudfour/modulecommon/util/PassportUtil.java
@@ -1,0 +1,96 @@
+package com.example.cloudfour.modulecommon.util;
+
+import com.example.cloudfour.modulecommon.dto.Passport;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+@Slf4j
+@Component
+public class PassportUtil {
+    
+    private static final ObjectMapper objectMapper = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);   
+    private static final String HMAC_SHA256 = "HmacSHA256";
+    private static final String DEFAULT_SECRET_KEY = "default-secret-key-change-in-production";
+    
+    @Value("${passport.secret-key:default-secret-key-change-in-production}")
+    private String secretKey;
+
+    public String serialize(Passport passport) {
+        try {
+            byte[] payload = objectMapper.writeValueAsBytes(passport);
+            String payloadB64 = Base64.getUrlEncoder().withoutPadding().encodeToString(payload);
+
+            String sigB64 = signB64Url(payload);
+            return payloadB64 + "." + sigB64;
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Passport 직렬화 실패", e);
+        }
+    }
+
+    private String signB64Url(byte[] data) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_SHA256);
+            String keyToUse = (secretKey != null) ? secretKey : DEFAULT_SECRET_KEY;
+            mac.init(new SecretKeySpec(keyToUse.getBytes(StandardCharsets.UTF_8), HMAC_SHA256));
+            byte[] sig = mac.doFinal(data);
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(sig);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new RuntimeException("HMAC 서명 생성 실패", e);
+        }
+    }
+
+    public Passport deserialize(String passportData) {
+        try {
+            int dot = passportData.lastIndexOf('.');
+            if (dot < 0) throw new RuntimeException("잘못된 Passport 형식");
+
+            String payloadB64 = passportData.substring(0, dot);
+            String sigB64 = passportData.substring(dot + 1);
+
+            byte[] payload = Base64.getUrlDecoder().decode(payloadB64);
+            byte[] givenSig = Base64.getUrlDecoder().decode(sigB64);
+            byte[] expectSig = hmac(payload);
+
+            // 타이밍 공격 방지: 상수시간 비교
+            if (!java.security.MessageDigest.isEqual(expectSig, givenSig)) {
+                throw new RuntimeException("Passport 서명 검증 실패");
+            }
+            return objectMapper.readValue(payload, Passport.class);
+        } catch (Exception e) {
+            log.error("Passport 역직렬화 실패: {}", passportData, e);
+            throw new RuntimeException("Passport 역직렬화 실패", e);
+        }
+    }
+
+    private byte[] hmac(byte[] data) throws NoSuchAlgorithmException, InvalidKeyException {
+        Mac mac = Mac.getInstance(HMAC_SHA256);
+        String keyToUse = (secretKey != null) ? secretKey : DEFAULT_SECRET_KEY;
+        mac.init(new SecretKeySpec(keyToUse.getBytes(StandardCharsets.UTF_8), HMAC_SHA256));
+        return mac.doFinal(data);
+    }
+    
+    public Passport deserializeOrNull(String passportData) {
+        try {
+            return deserialize(passportData);
+        } catch (Exception e) {
+            log.warn("Passport 역직렬화 실패 (null 반환): {}", passportData);
+            return null;
+        }
+    }
+    
+}

--- a/payment-service/src/main/java/com/example/cloudfour/paymentservice/config/RestTemplateConfig.java
+++ b/payment-service/src/main/java/com/example/cloudfour/paymentservice/config/RestTemplateConfig.java
@@ -1,19 +1,21 @@
 package com.example.cloudfour.paymentservice.config;
 
+import com.example.cloudfour.modulecommon.error.RestTemplateResponseErrorHandler;
+import com.example.cloudfour.modulecommon.passport.interceptor.PassportInterceptor;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class RestTemplateConfig {
 
     @Bean
-    public RestTemplate restTemplate() {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(5000);
-        factory.setReadTimeout(10000);
-        
-        return new RestTemplate(factory);
+    @LoadBalanced
+    public RestTemplate restTemplate(RestTemplateBuilder builder, PassportInterceptor passportInterceptor) {
+        return builder.errorHandler(new RestTemplateResponseErrorHandler())
+                .interceptors(passportInterceptor)
+                .build();
     }
 }

--- a/payment-service/src/main/java/com/example/cloudfour/paymentservice/config/security/SecurityConfig.java
+++ b/payment-service/src/main/java/com/example/cloudfour/paymentservice/config/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.cloudfour.paymentservice.config.security;
 
-import com.example.cloudfour.modulecommon.filter.JwtClaimsAuthFilter;
+import com.example.cloudfour.modulecommon.passport.filter.InternalPassportFilter;
+import com.example.cloudfour.modulecommon.util.PassportUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -14,22 +15,23 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     @Bean
-    JwtClaimsAuthFilter jwtClaimsAuthFilter() {
-        return new JwtClaimsAuthFilter();
+    InternalPassportFilter internalPassportFilter(PassportUtil passportUtil) {
+        return new InternalPassportFilter(passportUtil);
     }
 
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http, JwtClaimsAuthFilter jwtClaimsAuthFilter) throws Exception {
+    SecurityFilterChain securityFilterChain(HttpSecurity http, InternalPassportFilter internalPassportFilter) throws Exception {
         return http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/internal/**", "/actuator/**", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
+                        .requestMatchers("/actuator/**", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
                         .requestMatchers("/api/payments/webhook").permitAll()
+                        .requestMatchers("/internal/**").authenticated()
                         .requestMatchers("/api/payments/**").authenticated()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(jwtClaimsAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(internalPassportFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 }

--- a/payment-service/src/main/java/com/example/cloudfour/paymentservice/domain/payment/controller/PaymentController.java
+++ b/payment-service/src/main/java/com/example/cloudfour/paymentservice/domain/payment/controller/PaymentController.java
@@ -1,7 +1,7 @@
 package com.example.cloudfour.paymentservice.domain.payment.controller;
 
 import com.example.cloudfour.modulecommon.apiPayLoad.CustomResponse;
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import com.example.cloudfour.paymentservice.domain.payment.dto.PaymentRequestDTO;
 import com.example.cloudfour.paymentservice.domain.payment.dto.PaymentResponseDTO;
 import com.example.cloudfour.paymentservice.domain.payment.service.command.PaymentCommandService;
@@ -33,13 +33,13 @@ public class PaymentController {
 
     @PostMapping("/confirm")
     @Operation(summary = "결제 승인", description = "프론트엔드에서 받은 결제 정보를 승인합니다.")
-    @PreAuthorize("hasRole('ROLE_CUSTOMER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     public CustomResponse<PaymentResponseDTO.PaymentConfirmResponseDTO> confirmPayment(
             @Valid @RequestBody PaymentRequestDTO.PaymentConfirmRequestDTO request,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        log.info("결제 승인 요청: paymentKey={}, orderId={}, userId={}", request.getPaymentKey(), request.getOrderId(), user.id());
-        PaymentResponseDTO.PaymentConfirmResponseDTO response = paymentCommandService.confirmPayment(request, user.id());
+        log.info("결제 승인 요청: paymentKey={}, orderId={}, userId={}", request.getPaymentKey(), request.getOrderId(), passport.getUserId());
+        PaymentResponseDTO.PaymentConfirmResponseDTO response = paymentCommandService.confirmPayment(request, passport.getUserId());
         return CustomResponse.onSuccess(HttpStatus.OK, response);
     }
 
@@ -52,38 +52,38 @@ public class PaymentController {
     }
 
     @PatchMapping("/{orderId}/cancel")
-    @PreAuthorize("hasRole('ROLE_MASTER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_MASTER')")
     @Operation(summary = "결제 취소", description = "결제를 취소합니다.")
     public CustomResponse<PaymentResponseDTO.PaymentCancelResponseDTO> cancelPayment(
             @Valid @RequestBody PaymentRequestDTO.PaymentCancelRequestDTO request,
             @PathVariable("orderId") UUID orderId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        log.info("결제 취소 요청: orderId={}, userId={}", orderId, user.id());
-        PaymentResponseDTO.PaymentCancelResponseDTO response = paymentCommandService.cancelPayment(request, orderId, user.id());
+        log.info("결제 취소 요청: orderId={}, userId={}", orderId, passport.getUserId());
+        PaymentResponseDTO.PaymentCancelResponseDTO response = paymentCommandService.cancelPayment(request, orderId, passport.getUserId());
         return CustomResponse.onSuccess(HttpStatus.OK, response);
     }
 
     @GetMapping("/{orderId}")
     @Operation(summary = "결제 상세 조회", description = "결제 상세 정보를 조회합니다.")
-    @PreAuthorize("hasRole('ROLE_CUSTOMER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     public CustomResponse<PaymentResponseDTO.PaymentDetailResponseDTO> getPayment(
             @PathVariable("orderId") UUID orderId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        log.info("결제 상세 조회 요청: orderId={}, userId={}", orderId, user.id());
-        PaymentResponseDTO.PaymentDetailResponseDTO response = paymentQueryService.getDetailPayment(orderId, user.id());
+        log.info("결제 상세 조회 요청: orderId={}, userId={}", orderId, passport.getUserId());
+        PaymentResponseDTO.PaymentDetailResponseDTO response = paymentQueryService.getDetailPayment(orderId, passport.getUserId());
         return CustomResponse.onSuccess(HttpStatus.OK, response);
     }
 
     @GetMapping("/me")
     @Operation(summary = "내 결제 이력", description = "내 결제 이력을 조회합니다.")
-    @PreAuthorize("hasRole('ROLE_CUSTOMER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     public CustomResponse<PaymentResponseDTO.PaymentUserListResponseDTO> getUserPayments(
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        log.info("내 결제 이력 조회 요청: userId={}", user.id());
-        PaymentResponseDTO.PaymentUserListResponseDTO response = paymentQueryService.getUserListPayment(user.id());
+        log.info("내 결제 이력 조회 요청: userId={}", passport.getUserId());
+        PaymentResponseDTO.PaymentUserListResponseDTO response = paymentQueryService.getUserListPayment(passport.getUserId());
         return CustomResponse.onSuccess(HttpStatus.OK, response);
     }
 }

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -39,6 +39,9 @@ spring:
     default-consumes-media-type: application/json
     default-produces-media-type: application/json
 
+passport:
+  secret-key: ${PASSPORT_SECRET}
+
 toss:
   secret-key: ${TOSS_SECRET}
   webhook-secret: ${TOSS_WEBHOOK_SECRET:webhook_secret_key}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/config/RestTemplateConfig.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/config/RestTemplateConfig.java
@@ -1,6 +1,7 @@
 package com.example.cloudfour.storeservice.config;
 
 import com.example.cloudfour.modulecommon.error.RestTemplateResponseErrorHandler;
+import com.example.cloudfour.modulecommon.passport.interceptor.PassportInterceptor;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
@@ -12,7 +13,9 @@ public class RestTemplateConfig {
 
     @Bean
     @LoadBalanced
-    public RestTemplate restTemplate(RestTemplateBuilder builder) {
-        return builder.errorHandler(new RestTemplateResponseErrorHandler()).build();
+    public RestTemplate restTemplate(RestTemplateBuilder builder, PassportInterceptor passportInterceptor) {
+        return builder.errorHandler(new RestTemplateResponseErrorHandler())
+                .interceptors(passportInterceptor)
+                .build();
     }
 }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/config/security/SecurityConfig.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/config/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.cloudfour.storeservice.config.security;
 
-import com.example.cloudfour.modulecommon.filter.JwtClaimsAuthFilter;
+import com.example.cloudfour.modulecommon.passport.filter.InternalPassportFilter;
+import com.example.cloudfour.modulecommon.util.PassportUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -14,21 +15,22 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     @Bean
-    JwtClaimsAuthFilter jwtClaimsAuthFilter() {
-        return new JwtClaimsAuthFilter();
+    InternalPassportFilter internalPassportFilter(PassportUtil passportUtil) {
+        return new InternalPassportFilter(passportUtil);
     }
 
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain securityFilterChain(HttpSecurity http, InternalPassportFilter internalPassportFilter) throws Exception {
         return http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/internal/**", "/actuator/**", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
+                        .requestMatchers("/actuator/**", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
+                        .requestMatchers("/internal/**").authenticated()
                         .requestMatchers("/stores/**","/menus/**","/reviews/**", "/profile/**").authenticated()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtClaimsAuthFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(internalPassportFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/controller/MenuController.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/controller/MenuController.java
@@ -1,7 +1,7 @@
 package com.example.cloudfour.storeservice.domain.menu.controller;
 
 import com.example.cloudfour.modulecommon.apiPayLoad.CustomResponse;
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import com.example.cloudfour.storeservice.domain.menu.dto.MenuRequestDTO;
 import com.example.cloudfour.storeservice.domain.menu.dto.MenuResponseDTO;
 import com.example.cloudfour.storeservice.domain.menu.dto.MenuOptionResponseDTO;
@@ -36,14 +36,14 @@ public class MenuController {
     private final MenuQueryService menuQueryService;
 
     @PostMapping("/{storeId}")
-    @PreAuthorize("hasRole('ROLE_OWNER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_OWNER')")
     @Operation(summary = "메뉴 생성", description = "메뉴를 생성합니다.")
     public CustomResponse<MenuResponseDTO.MenuDetailResponseDTO> createMenu(
             @PathVariable("storeId") UUID storeId,
             @Valid @RequestBody MenuRequestDTO.MenuCreateRequestDTO requestDTO,
-            @AuthenticationPrincipal CurrentUser user) {
+            @AuthenticationPrincipal Passport passport) {
 
-        MenuResponseDTO.MenuDetailResponseDTO result = menuCommandService.createMenu(requestDTO, storeId, user);
+        MenuResponseDTO.MenuDetailResponseDTO result = menuCommandService.createMenu(requestDTO, storeId, passport);
         return CustomResponse.onSuccess(HttpStatus.CREATED, result);
     }
 
@@ -51,9 +51,9 @@ public class MenuController {
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "메뉴 상세 조회", description = "메뉴의 상세 정보를 조회합니다.")
     public CustomResponse<MenuResponseDTO.MenuDetailResponseDTO> getMenuDetail(
-            @PathVariable("menuId") UUID menuId,@AuthenticationPrincipal CurrentUser user) {
+            @PathVariable("menuId") UUID menuId,@AuthenticationPrincipal Passport passport) {
 
-        MenuResponseDTO.MenuDetailResponseDTO result = menuQueryService.getMenuDetail(menuId,user);
+        MenuResponseDTO.MenuDetailResponseDTO result = menuQueryService.getMenuDetail(menuId,passport);
         return CustomResponse.onSuccess(HttpStatus.OK, result);
     }
 
@@ -62,11 +62,11 @@ public class MenuController {
     @Operation(summary = "해당 가게 메뉴 목록 조회", description = "가게의 메뉴 목록을 조회합니다.")
     public CustomResponse<MenuResponseDTO.MenuStoreListResponseDTO> getMenusByStore(
             @PathVariable("storeId") UUID storeId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
         ) {
 
         MenuResponseDTO.MenuStoreListResponseDTO result =
-                menuQueryService.getMenusByStoreWithCursor(storeId,user);
+                menuQueryService.getMenusByStoreWithCursor(storeId,passport);
         return CustomResponse.onSuccess(HttpStatus.OK, result);
     }
 
@@ -76,47 +76,47 @@ public class MenuController {
     public CustomResponse<MenuResponseDTO.MenuStoreListResponseDTO> getMenusByCategory(
             @PathVariable("storeId") UUID storeId,
             @RequestParam(name = "categoryId") UUID categoryId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
             ) {
 
         MenuResponseDTO.MenuStoreListResponseDTO result =
-                menuQueryService.getMenusByStoreWithCategory(storeId, categoryId, user);
+                menuQueryService.getMenusByStoreWithCategory(storeId, categoryId, passport);
         return CustomResponse.onSuccess(HttpStatus.OK, result);
     }
 
     @PatchMapping("/{menuId}")
-    @PreAuthorize("hasRole('ROLE_OWNER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_OWNER')")
     @Operation(summary = "메뉴 수정", description = "메뉴를 수정합니다.")
     public CustomResponse<MenuResponseDTO.MenuDetailResponseDTO> updateMenu(
             @Valid @RequestBody MenuRequestDTO.MenuUpdateRequestDTO requestDTO,
             @PathVariable("menuId") UUID menuId,
-            @AuthenticationPrincipal CurrentUser user) {
+            @AuthenticationPrincipal Passport passport) {
 
-        MenuResponseDTO.MenuDetailResponseDTO result = menuCommandService.updateMenu(menuId, requestDTO, user);
+        MenuResponseDTO.MenuDetailResponseDTO result = menuCommandService.updateMenu(menuId, requestDTO, passport);
         return CustomResponse.onSuccess(HttpStatus.OK, result);
     }
 
     @DeleteMapping("/{menuId}/deleted")
-    @PreAuthorize("(hasRole('ROLE_OWNER') and authentication.principal.id == #user.id()) or hasRole('ROLE_MASTER')")
+    @PreAuthorize("hasRole('ROLE_OWNER') or hasRole('ROLE_MASTER')")
     @Operation(summary = "메뉴 삭제", description = "메뉴를 삭제합니다.")
     public CustomResponse<String> deleteMenu(
             @PathVariable("menuId") UUID menuId,
-            @AuthenticationPrincipal CurrentUser user) {
+            @AuthenticationPrincipal Passport passport) {
 
-        menuCommandService.deleteMenu(menuId, user);
+        menuCommandService.deleteMenu(menuId, passport);
         return CustomResponse.onSuccess(HttpStatus.OK, "메뉴 삭제 완료");
     }
 
     @PostMapping("/{menuId}/options")
-    @PreAuthorize("hasRole('ROLE_OWNER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_OWNER')")
     @Operation(summary = "메뉴 옵션 생성", description = "특정 메뉴에 새로운 옵션을 추가합니다.")
     public CustomResponse<MenuOptionResponseDTO.MenuOptionSimpleResponseDTO> createMenuOption(
             @PathVariable("menuId") UUID menuId,
             @Valid @RequestBody MenuRequestDTO.MenuOptionCreateRequestDTO requestDTO,
-            @AuthenticationPrincipal CurrentUser user) {
+            @AuthenticationPrincipal Passport passport) {
 
         MenuOptionResponseDTO.MenuOptionSimpleResponseDTO result =
-                menuCommandService.createMenuOption(requestDTO, user, menuId);
+                menuCommandService.createMenuOption(requestDTO, passport, menuId);
         return CustomResponse.onSuccess(HttpStatus.CREATED, result);
     }
 
@@ -124,11 +124,11 @@ public class MenuController {
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "메뉴별 옵션 목록 조회", description = "특정 메뉴의 모든 옵션을 조회합니다.")
     public CustomResponse<MenuOptionResponseDTO.MenuOptionsByMenuResponseDTO> getMenuOptions(
-            @PathVariable("menuId") UUID menuId,@AuthenticationPrincipal CurrentUser user
+            @PathVariable("menuId") UUID menuId, @AuthenticationPrincipal Passport passport
             ) {
 
         MenuOptionResponseDTO.MenuOptionsByMenuResponseDTO result =
-                menuQueryService.getMenuOptionsByMenu(menuId,user);
+                menuQueryService.getMenuOptionsByMenu(menuId, passport);
         return CustomResponse.onSuccess(HttpStatus.OK, result);
     }
 
@@ -136,35 +136,35 @@ public class MenuController {
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "메뉴 옵션 상세 조회", description = "메뉴 옵션의 상세 정보를 조회합니다.")
     public CustomResponse<MenuOptionResponseDTO.MenuOptionSimpleResponseDTO> getMenuOptionDetail(
-            @PathVariable("optionId") UUID optionId,@AuthenticationPrincipal CurrentUser user
+            @PathVariable("optionId") UUID optionId, @AuthenticationPrincipal Passport passport
             ) {
 
         MenuOptionResponseDTO.MenuOptionSimpleResponseDTO result =
-                menuQueryService.getMenuOptionDetail(optionId,user);
+                menuQueryService.getMenuOptionDetail(optionId, passport);
         return CustomResponse.onSuccess(HttpStatus.OK, result);
     }
 
     @PatchMapping("/options/{optionId}")
-    @PreAuthorize("(hasRole('ROLE_OWNER') and authentication.principal.id == #user.id()) or hasRole('ROLE_MASTER')")
+    @PreAuthorize("hasRole('ROLE_OWNER') or hasRole('ROLE_MASTER')")
     @Operation(summary = "메뉴 옵션 수정", description = "메뉴 옵션의 정보를 수정합니다.")
     public CustomResponse<MenuOptionResponseDTO.MenuOptionSimpleResponseDTO> updateMenuOption(
             @PathVariable("optionId") UUID optionId,
             @Valid @RequestBody MenuRequestDTO.MenuOptionUpdateRequestDTO requestDTO,
-            @AuthenticationPrincipal CurrentUser user) {
+            @AuthenticationPrincipal Passport passport) {
 
         MenuOptionResponseDTO.MenuOptionSimpleResponseDTO result =
-                menuCommandService.updateMenuOption(optionId, requestDTO, user);
+                menuCommandService.updateMenuOption(optionId, requestDTO, passport);
         return CustomResponse.onSuccess(HttpStatus.OK, result);
     }
 
     @DeleteMapping("/options/{optionId}/deleted")
-    @PreAuthorize("(hasRole('ROLE_OWNER') and authentication.principal.id == #user.id()) or hasRole('ROLE_MASTER')")
+    @PreAuthorize("hasRole('ROLE_OWNER') or hasRole('ROLE_MASTER')")
     @Operation(summary = "메뉴 옵션 삭제", description = "메뉴 옵션을 삭제합니다.")
     public CustomResponse<String> deleteMenuOption(
             @PathVariable("optionId") UUID optionId,
-            @AuthenticationPrincipal CurrentUser user) {
+            @AuthenticationPrincipal Passport passport) {
 
-        menuCommandService.deleteMenuOption(optionId, user);
+        menuCommandService.deleteMenuOption(optionId, passport);
         return CustomResponse.onSuccess(HttpStatus.OK, "메뉴 옵션 삭제 완료");
     }
 }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/service/command/MenuCommandService.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/service/command/MenuCommandService.java
@@ -1,6 +1,6 @@
 package com.example.cloudfour.storeservice.domain.menu.service.command;
 
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import com.example.cloudfour.storeservice.domain.menu.converter.MenuConverter;
 import com.example.cloudfour.storeservice.domain.menu.converter.MenuOptionConverter;
 import com.example.cloudfour.storeservice.domain.menu.dto.MenuRequestDTO;
@@ -43,7 +43,7 @@ public class MenuCommandService {
     public MenuResponseDTO.MenuDetailResponseDTO createMenu(
             MenuRequestDTO.MenuCreateRequestDTO requestDTO,
             UUID storeId,
-            CurrentUser user
+            Passport passport
     ) {
         Store store = storeRepository.findByIdAndIsDeletedFalse(storeId)
                 .orElseThrow(() -> {
@@ -51,7 +51,7 @@ public class MenuCommandService {
                     return new StoreException(StoreErrorCode.NOT_FOUND);
                 });
 
-        if (user == null || !store.getOwnerId().equals(user.id())) {
+        if (passport == null || !store.getOwnerId().equals(passport.getUserId())) {
             log.warn("메뉴 생성 권한 없음");
             throw new MenuException(MenuErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -84,7 +84,7 @@ public class MenuCommandService {
     public MenuResponseDTO.MenuDetailResponseDTO updateMenu(
             UUID menuId,
             MenuRequestDTO.MenuUpdateRequestDTO requestDTO,
-            CurrentUser user
+            Passport passport
     ) {
         Menu menu = menuRepository.findById(menuId)
                 .orElseThrow(() -> {
@@ -92,7 +92,7 @@ public class MenuCommandService {
                     return new MenuException(MenuErrorCode.NOT_FOUND);
                 });
 
-        if (user == null || !menu.getStore().getOwnerId().equals(user.id())) {
+        if (passport == null || !menu.getStore().getOwnerId().equals(passport.getUserId())) {
             log.warn("메뉴 수정 권한 없음");
             throw new MenuException(MenuErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -130,14 +130,14 @@ public class MenuCommandService {
     }
 
     
-    public void deleteMenu(UUID menuId, CurrentUser user) {
+    public void deleteMenu(UUID menuId, Passport passport) {
         Menu menu = menuRepository.findById(menuId)
                 .orElseThrow(() -> {
                     log.warn("존재하지 않는 메뉴");
                     return new MenuException(MenuErrorCode.NOT_FOUND);
                 });
 
-        if (user == null || !menu.getStore().getOwnerId().equals(user.id())) {
+        if (passport == null || !menu.getStore().getOwnerId().equals(passport.getUserId())) {
             log.warn("메뉴 삭제 권한 없음");
             throw new MenuException(MenuErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -148,7 +148,7 @@ public class MenuCommandService {
 
     public MenuOptionResponseDTO.MenuOptionSimpleResponseDTO createMenuOption(
             MenuRequestDTO.MenuOptionCreateRequestDTO requestDTO,
-            CurrentUser user, UUID menuId
+            Passport passport, UUID menuId
     ) {
         Menu menu = menuRepository.findById(menuId)
                 .orElseThrow(() -> {
@@ -157,7 +157,7 @@ public class MenuCommandService {
                 });
 
 
-        if (user == null || !menu.getStore().getOwnerId().equals(user.id())) {
+        if (passport == null || !menu.getStore().getOwnerId().equals(passport.getUserId())) {
             log.warn("메뉴 옵션 생성 권한 없음");
             throw new MenuOptionException(MenuOptionErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -182,7 +182,7 @@ public class MenuCommandService {
     public MenuOptionResponseDTO.MenuOptionSimpleResponseDTO updateMenuOption(
             UUID optionId,
             MenuRequestDTO.MenuOptionUpdateRequestDTO requestDTO,
-            CurrentUser user
+            Passport passport
     ) {
         MenuOption menuOption = menuOptionRepository.findByIdWithMenu(optionId)
                 .orElseThrow(() -> {
@@ -190,7 +190,7 @@ public class MenuCommandService {
                     return new MenuOptionException(MenuOptionErrorCode.NOT_FOUND);
                 });
 
-        if (user==null || !menuOption.getMenu().getStore().getOwnerId().equals(user.id())) {
+        if (passport ==null || !menuOption.getMenu().getStore().getOwnerId().equals(passport.getUserId())) {
             log.warn("메뉴 옵션 수정 권한 없음");
             throw new MenuOptionException(MenuOptionErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -208,14 +208,14 @@ public class MenuCommandService {
     }
 
     
-    public void deleteMenuOption(UUID optionId, CurrentUser user) {
+    public void deleteMenuOption(UUID optionId, Passport passport) {
         MenuOption menuOption = menuOptionRepository.findByIdWithMenu(optionId)
                 .orElseThrow(() -> {
                     log.warn("존재하지 않는 메뉴옵션");
                     return new MenuOptionException(MenuOptionErrorCode.NOT_FOUND);
                 });
 
-        if (user == null || !menuOption.getMenu().getStore().getOwnerId().equals(user.id())) {
+        if (passport == null || !menuOption.getMenu().getStore().getOwnerId().equals(passport.getUserId())) {
             log.warn("메뉴 옵션 삭제 권한 없음");
             throw new MenuException(MenuErrorCode.UNAUTHORIZED_ACCESS);
         }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/service/query/MenuQueryService.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/service/query/MenuQueryService.java
@@ -1,6 +1,6 @@
 package com.example.cloudfour.storeservice.domain.menu.service.query;
 
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import com.example.cloudfour.storeservice.domain.collection.document.StoreDocument;
 import com.example.cloudfour.storeservice.domain.collection.repository.query.StoreSearchRepository;
 import com.example.cloudfour.storeservice.domain.commondto.MenuCartResponseDTO;
@@ -44,14 +44,14 @@ public class MenuQueryService {
     private final StockQueryService stockQueryService;
 
     public MenuResponseDTO.MenuStoreListResponseDTO getMenusByStoreWithCursor(
-            UUID storeId, CurrentUser user
+            UUID storeId, Passport passport
     ) {
         storeMongoRepository.findStoreByStoreId(storeId).orElseThrow(() -> {
             log.warn("존재하지 않는 가게");
             return new StoreException(StoreErrorCode.NOT_FOUND);
         });
 
-        if(user==null){
+        if(passport==null){
             log.warn("가게 메뉴 조회 권한 없음");
             throw new MenuException(MenuErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -87,7 +87,7 @@ public class MenuQueryService {
     }
 
     public MenuResponseDTO.MenuStoreListResponseDTO getMenusByStoreWithCategory(
-            UUID storeId, UUID categoryId,CurrentUser user
+            UUID storeId, UUID categoryId,Passport passport
     ) {
         storeMongoRepository.findStoreByStoreId(storeId)
                 .orElseThrow(() -> {
@@ -100,7 +100,7 @@ public class MenuQueryService {
                     return new MenuCategoryException(MenuCategoryErrorCode.NOT_FOUND);
                 });
 
-        if(user==null){
+        if(passport==null){
             log.warn("가게, 카테고리 별 메뉴 목록 조회 권한 없음");
             throw new MenuException(MenuErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -138,8 +138,33 @@ public class MenuQueryService {
                 .build();
     }
 
-    public MenuResponseDTO.MenuDetailResponseDTO getMenuDetail(UUID menuId,CurrentUser user) {
-        if(user==null){
+//    public List<MenuResponseDTO.MenuTopResponseDTO> getTopMenus(UUID userId) {
+//        OrderItemResponseDTO orderItemResponseDTO = restTemplate.getForObject("http://order-service/api/order-items/{userId}", OrderItemResponseDTO.class, userId);
+//        return menuRepository.findTopMenusByOrderCount(PageRequest.of(0, 20))
+//                .stream()
+//                .map(MenuConverter::toMenuTopResponseDTO)
+//                .toList();
+//    }
+//
+//    public List<MenuResponseDTO.MenuTimeTopResponseDTO> getTimeTopMenus(UUID userId) {
+//        LocalDateTime startTime = LocalDateTime.now().minusHours(24);
+//        LocalDateTime endTime = LocalDateTime.now();
+//
+//        return menuRepository.findTopMenusByTimeRange(startTime, endTime, PageRequest.of(0, 20))
+//                .stream()
+//                .map(MenuConverter::toMenuTimeTopResponseDTO)
+//                .toList();
+//    }
+//
+//    public List<MenuResponseDTO.MenuRegionTopResponseDTO> getRegionTopMenus(String si, String gu, UUID userId) {
+//        return menuRepository.findTopMenusByRegion(si, gu, PageRequest.of(0, 20))
+//                .stream()
+//                .map(MenuConverter::toMenuRegionTopResponseDTO)
+//                .toList();
+//    }
+
+    public MenuResponseDTO.MenuDetailResponseDTO getMenuDetail(UUID menuId,Passport passport) {
+        if(passport==null){
             log.warn("메뉴 상세 조회 권한 없음");
             throw new MenuException(MenuErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -160,8 +185,8 @@ public class MenuQueryService {
         return MenuConverter.toMenuDetail2ResponseDTO(storeDocument, optionDTOs);
     }
 
-    public MenuOptionResponseDTO.MenuOptionsByMenuResponseDTO getMenuOptionsByMenu(UUID menuId,CurrentUser user) {
-        if(user==null){
+    public MenuOptionResponseDTO.MenuOptionsByMenuResponseDTO getMenuOptionsByMenu(UUID menuId,Passport passport) {
+        if(passport==null){
             log.warn("메뉴 별 메뉴 옵션 조회 권한 없음");
             throw new MenuOptionException(MenuOptionErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -183,8 +208,8 @@ public class MenuQueryService {
                 .build();
     }
 
-    public MenuOptionResponseDTO.MenuOptionSimpleResponseDTO getMenuOptionDetail(UUID optionId,CurrentUser user) {
-        if(user==null){
+    public MenuOptionResponseDTO.MenuOptionSimpleResponseDTO getMenuOptionDetail(UUID optionId,Passport passport) {
+        if(passport==null){
             log.warn("메뉴 옵션 상세 조회 권한 없음");
             throw new MenuOptionException(MenuOptionErrorCode.UNAUTHORIZED_ACCESS);
         }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/review/controller/ReviewController.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/review/controller/ReviewController.java
@@ -2,6 +2,7 @@ package com.example.cloudfour.storeservice.domain.review.controller;
 
 import com.example.cloudfour.modulecommon.apiPayLoad.CustomResponse;
 import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import com.example.cloudfour.storeservice.domain.review.dto.ReviewRequestDTO;
 import com.example.cloudfour.storeservice.domain.review.dto.ReviewResponseDTO;
 import com.example.cloudfour.storeservice.domain.review.service.command.ReviewCommandService;
@@ -35,36 +36,36 @@ public class ReviewController {
     private final ReviewQueryService reviewQueryService;
 
     @PostMapping("")
-    @PreAuthorize("hasRole('ROLE_CUSTOMER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "리뷰 생성", description = "리뷰를 생성합니다. 리뷰 생성에 사용되는 API입니다.")
     public CustomResponse<ReviewResponseDTO.ReviewCreateResponseDTO> createReview(
             @Valid @RequestBody ReviewRequestDTO.ReviewCreateRequestDTO reviewCreateRequestDTO,
-        @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        ReviewResponseDTO.ReviewCreateResponseDTO review = reviewCommandService.createReview(reviewCreateRequestDTO,user);
+        ReviewResponseDTO.ReviewCreateResponseDTO review = reviewCommandService.createReview(reviewCreateRequestDTO, passport);
         return CustomResponse.onSuccess(HttpStatus.CREATED, review);
     }
 
     @PatchMapping("/{reviewId}")
-    @PreAuthorize("hasRole('ROLE_CUSTOMER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "리뷰 수정", description = "리뷰를 수정합니다. 리뷰 수정에 사용되는 API입니다.")
     public CustomResponse<ReviewResponseDTO.ReviewUpdateResponseDTO> updateReview(
             @Valid @RequestBody ReviewRequestDTO.ReviewUpdateRequestDTO reviewUpdateRequestDTO,
             @PathVariable("reviewId") UUID reviewId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        ReviewResponseDTO.ReviewUpdateResponseDTO review = reviewCommandService.updateReview(reviewUpdateRequestDTO,reviewId,user);
+        ReviewResponseDTO.ReviewUpdateResponseDTO review = reviewCommandService.updateReview(reviewUpdateRequestDTO,reviewId,passport);
         return CustomResponse.onSuccess(HttpStatus.OK, review);
     }
 
     @PatchMapping("/{reviewId}/canceled")
-    @PreAuthorize("(hasRole('ROLE_CUSTOMER') and authentication.principal.id == #user.id()) or hasRole('ROLE_MASTER')")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER') or hasRole('ROLE_MASTER')")
     @Operation(summary = "리뷰 삭제", description = "리뷰를 삭제합니다. 리뷰 삭제에 사용되는 API입니다.")
     public CustomResponse<String> deleteReview(
             @PathVariable("reviewId") UUID reviewId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        reviewCommandService.deleteReview(reviewId,user);
+        reviewCommandService.deleteReview(reviewId,passport);
         return CustomResponse.onSuccess(HttpStatus.OK, "리뷰 삭제 완료");
     }
 
@@ -73,23 +74,23 @@ public class ReviewController {
     @Operation(summary = "리뷰 상세 조회", description = "리뷰를 상세 조회합니다. 리뷰 상세 조회에 사용되는 API입니다.")
     public CustomResponse<ReviewResponseDTO.ReviewDetailResponseDTO> getReview(
             @PathVariable("reviewId") UUID reviewId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ){
-        ReviewResponseDTO.ReviewDetailResponseDTO review = reviewQueryService.getReviewById(reviewId,user);
+        ReviewResponseDTO.ReviewDetailResponseDTO review = reviewQueryService.getReviewById(reviewId,passport);
         return CustomResponse.onSuccess(HttpStatus.OK, review);
     }
 
     @GetMapping("")
-    @PreAuthorize("(hasRole('ROLE_CUSTOMER') and authentication.principal.id == #user.id())")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "유저 리뷰 조회", description = "사용자가 작성한 리뷰를 조회합니다. 사용자 리뷰 조회에 사용되는 API입니다.")
     @Parameter(name = "cursor", description = "데이터가 시작하는 부분을 표시합니다")
     @Parameter(name = "size", description = "size만큼 데이터를 가져옵니다.")
     public CustomResponse<ReviewResponseDTO.ReviewUserListResponseDTO> getUserReviews(
-            @AuthenticationPrincipal CurrentUser user,
+            @AuthenticationPrincipal Passport passport,
             @RequestParam(name = "cursor", required = false) LocalDateTime cursor,
             @RequestParam(name = "size", defaultValue = "10") Integer size
     ){
-        ReviewResponseDTO.ReviewUserListResponseDTO review = reviewQueryService.getReviewListByUser(cursor,size,user);
+        ReviewResponseDTO.ReviewUserListResponseDTO review = reviewQueryService.getReviewListByUser(cursor,size,passport);
         return CustomResponse.onSuccess(HttpStatus.OK, review);
     }
 
@@ -100,11 +101,11 @@ public class ReviewController {
     @Parameter(name = "size", description = "size만큼 데이터를 가져옵니다.")
     public CustomResponse<ReviewResponseDTO.ReviewStoreListResponseDTO> getStoreReviews(
             @PathVariable("storeId") UUID storeId,
-            @AuthenticationPrincipal CurrentUser user,
+            @AuthenticationPrincipal Passport passport,
             @RequestParam(name = "cursor", required = false) LocalDateTime cursor,
             @RequestParam(name = "size", defaultValue = "10") Integer size
     ){
-        ReviewResponseDTO.ReviewStoreListResponseDTO review = reviewQueryService.getReviewListByStore(storeId,cursor,size,user);
+        ReviewResponseDTO.ReviewStoreListResponseDTO review = reviewQueryService.getReviewListByStore(storeId,cursor,size,passport);
         return CustomResponse.onSuccess(HttpStatus.OK, review);
     }
 }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/review/service/command/ReviewCommandService.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/review/service/command/ReviewCommandService.java
@@ -1,6 +1,6 @@
 package com.example.cloudfour.storeservice.domain.review.service.command;
 
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import com.example.cloudfour.storeservice.domain.review.converter.ReviewConverter;
 import com.example.cloudfour.storeservice.domain.review.dto.ReviewRequestDTO;
 import com.example.cloudfour.storeservice.domain.review.dto.ReviewResponseDTO;
@@ -28,8 +28,8 @@ public class ReviewCommandService {
     private final ReviewRepository reviewRepository;
 
     public ReviewResponseDTO.ReviewCreateResponseDTO createReview(ReviewRequestDTO.ReviewCreateRequestDTO reviewCreateRequestDTO,
-          CurrentUser user) {
-        if(user==null){
+          Passport passport) {
+        if(passport==null){
             log.warn("리뷰 생성 권한 없음");
             throw new ReviewException(ReviewErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -40,19 +40,19 @@ public class ReviewCommandService {
             return new StoreException(StoreErrorCode.NOT_FOUND);
         });
         Review review = ReviewConverter.toReview(reviewCreateRequestDTO);
-        review.setUser(user.id());
+        review.setUser(passport.getUserId());
         review.setStore(findStore);
         reviewRepository.save(review);
         log.info("리뷰 생성 성공");
         return ReviewConverter.toReviewCreateResponseDTO(review);
     }
 
-    public void deleteReview(UUID reviewId, CurrentUser user) {
+    public void deleteReview(UUID reviewId, Passport passport) {
         Review findReview = reviewRepository.findById(reviewId).orElseThrow(()->{
             log.warn("존재하지 않는 리뷰");
             return new ReviewException(ReviewErrorCode.NOT_FOUND);
         });
-        if(user == null || !reviewRepository.existsByReviewIdAndUserId(reviewId, user.id())) {
+        if(passport == null || !reviewRepository.existsByReviewIdAndUserId(reviewId, passport.getUserId())) {
             log.warn("리뷰 삭제 권한 없음");
             throw new ReviewException(ReviewErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -62,12 +62,12 @@ public class ReviewCommandService {
     }
 
     public ReviewResponseDTO.ReviewUpdateResponseDTO updateReview(ReviewRequestDTO.ReviewUpdateRequestDTO reviewUpdateRequestDTO,
-              UUID reviewId, CurrentUser user) {
+              UUID reviewId, Passport passport) {
         Review findReview = reviewRepository.findById(reviewId).orElseThrow(()->{
                 log.warn("존재하지 않는 리뷰");
                 return new ReviewException(ReviewErrorCode.NOT_FOUND);
         });
-        if(user == null || !reviewRepository.existsByReviewIdAndUserId(reviewId, user.id())) {
+        if(passport == null || !reviewRepository.existsByReviewIdAndUserId(reviewId, passport.getUserId())) {
             log.warn("리뷰 수정 권한 없음");
             throw new ReviewException(ReviewErrorCode.UNAUTHORIZED_ACCESS);
         }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/review/service/query/ReviewQueryService.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/review/service/query/ReviewQueryService.java
@@ -1,6 +1,6 @@
 package com.example.cloudfour.storeservice.domain.review.service.query;
 
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import com.example.cloudfour.storeservice.domain.collection.document.ReviewDocument;
 import com.example.cloudfour.storeservice.domain.collection.repository.query.ReviewSearchRepository;
 import com.example.cloudfour.storeservice.domain.common.UserResponseDTO;
@@ -35,13 +35,13 @@ public class ReviewQueryService {
     private static final LocalDateTime first_cursor = LocalDateTime.now().plusDays(1);
     private static final String BASE = "http://user-service/internal/users";
 
-    public ReviewResponseDTO.ReviewDetailResponseDTO getReviewById(UUID reviewId, CurrentUser user) {
-        if(user==null){
+    public ReviewResponseDTO.ReviewDetailResponseDTO getReviewById(UUID reviewId, Passport passport) {
+        if(passport==null){
             log.warn("상세 리뷰 조회 접근 권한 없음");
             throw new ReviewException(ReviewErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        UserResponseDTO findUser =  rt.getForObject(BASE+"/{id}",UserResponseDTO.class,user.id());
+        UserResponseDTO findUser =  rt.getForObject(BASE+"/{id}",UserResponseDTO.class,passport.getUserId());
 
         if(findUser == null){
             log.warn("상세 리뷰 조회 접근 권한 없음");
@@ -58,12 +58,12 @@ public class ReviewQueryService {
         return ReviewConverter.toReviewDetailResponseDTO(findReview,findReview.getUserName());
     }
 
-    public ReviewResponseDTO.ReviewStoreListResponseDTO getReviewListByStore(UUID storeId, LocalDateTime cursor, Integer size, CurrentUser user) {
+    public ReviewResponseDTO.ReviewStoreListResponseDTO getReviewListByStore(UUID storeId, LocalDateTime cursor, Integer size, Passport passport) {
         storeRepository.findById(storeId).orElseThrow(()->{
             log.warn("존재하지 않는 가게");
             return new StoreException(StoreErrorCode.NOT_FOUND);
         });
-        if(user==null){
+        if(passport==null){
             log.warn("가게 리뷰 목록 조회 접근 권한 없음");
             throw new ReviewException(ReviewErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -88,8 +88,8 @@ public class ReviewQueryService {
         return ReviewConverter.toReviewStoreListResponseDTO(reviewStoreListResponseDTOS,findReviews.hasNext(),next_cursor);
     }
 
-    public ReviewResponseDTO.ReviewUserListResponseDTO getReviewListByUser(LocalDateTime cursor, Integer size, CurrentUser user) {
-        if(user==null){
+    public ReviewResponseDTO.ReviewUserListResponseDTO getReviewListByUser(LocalDateTime cursor, Integer size, Passport passport) {
+        if(passport==null){
             log.warn("가게 리뷰 목록 조회 접근 권한 없음");
             throw new ReviewException(ReviewErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -98,7 +98,7 @@ public class ReviewQueryService {
         }
         log.info("사용자 리뷰 목록 조회 권한 확인 성공");
         Pageable pageable = PageRequest.of(0,size);
-        Slice<ReviewDocument> findReviews = reviewRepository.findAllByUserId(user.id(),cursor,pageable);
+        Slice<ReviewDocument> findReviews = reviewRepository.findAllByUserId(passport.getUserId(),cursor,pageable);
         if(findReviews.isEmpty()){
             log.info("사용자 리뷰 데이터 없음");
             throw new ReviewException(ReviewErrorCode.NOT_FOUND);

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/controller/StoreController.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/controller/StoreController.java
@@ -2,6 +2,7 @@ package com.example.cloudfour.storeservice.domain.store.controller;
 
 import com.example.cloudfour.modulecommon.apiPayLoad.CustomResponse;
 import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import com.example.cloudfour.storeservice.domain.store.dto.StoreRequestDTO;
 import com.example.cloudfour.storeservice.domain.store.dto.StoreResponseDTO;
 import com.example.cloudfour.storeservice.domain.store.service.command.StoreCommandService;
@@ -38,13 +39,13 @@ public class StoreController {
     private final StoreQueryService storeQueryService;
     
     @PostMapping("")
-    @PreAuthorize("hasRole('ROLE_OWNER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_OWNER')")
     @Operation(summary = "가게 등록", description = "가게를 등록합니다.")
     public CustomResponse<StoreResponseDTO.StoreCreateResponseDTO> createStore(
             @Valid  @RequestBody StoreRequestDTO.StoreCreateRequestDTO dto,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ) {
-        return CustomResponse.onSuccess(HttpStatus.CREATED, storeCommandService.createStore(dto, user));
+        return CustomResponse.onSuccess(HttpStatus.CREATED, storeCommandService.createStore(dto, passport));
     }
 
     @GetMapping("")
@@ -57,9 +58,9 @@ public class StoreController {
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursor,
             @RequestParam(name = "size", defaultValue = "10") Integer size,
             @RequestParam(name = "keyword", required = false) String keyword,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ) {
-        StoreResponseDTO.StoreCursorListResponseDTO response = storeQueryService.getAllStores(cursor, size,keyword,user);
+        StoreResponseDTO.StoreCursorListResponseDTO response = storeQueryService.getAllStores(cursor, size,keyword,passport);
         return CustomResponse.onSuccess(HttpStatus.OK, response);
     }
 
@@ -67,30 +68,30 @@ public class StoreController {
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "가게 상세 정보 조회", description = "가게의 상세 정보를 조회합니다.")
     public CustomResponse<StoreResponseDTO.StoreDetailResponseDTO> getStoreDetail(
-            @PathVariable UUID storeId,@AuthenticationPrincipal CurrentUser user
+            @PathVariable UUID storeId,@AuthenticationPrincipal Passport passport
     ) {
-        return CustomResponse.onSuccess(HttpStatus.OK, storeQueryService.getStoreById(storeId,user));
+        return CustomResponse.onSuccess(HttpStatus.OK, storeQueryService.getStoreById(storeId,passport));
     }
 
     @PatchMapping("/{storeId}")
-    @PreAuthorize("hasRole('ROLE_OWNER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_OWNER')")
     @Operation(summary = "가게 정보 수정", description = "본인의 가게 정보를 수정합니다.")
     public CustomResponse<StoreResponseDTO.StoreUpdateResponseDTO> updateStore(
             @PathVariable UUID storeId,
             @Valid @RequestBody StoreRequestDTO.StoreUpdateRequestDTO dto,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ) {
-        return CustomResponse.onSuccess(HttpStatus.OK, storeCommandService.updateStore(storeId, dto, user));
+        return CustomResponse.onSuccess(HttpStatus.OK, storeCommandService.updateStore(storeId, dto, passport));
     }
 
     @PatchMapping("/{storeId}/deleted")
-    @PreAuthorize("(hasRole('ROLE_OWNER') and authentication.principal.id == #user.id()) or hasRole('ROLE_MASTER')")
+    @PreAuthorize("hasRole('ROLE_OWNER') or hasRole('ROLE_MASTER')")
     @Operation(summary = "가게 삭제", description = "본인의 가게를 삭제합니다.")
     public CustomResponse<String> deleteStore(
             @PathVariable UUID storeId,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ) {
-        storeCommandService.deleteStore(storeId, user);
+        storeCommandService.deleteStore(storeId, passport);
         return CustomResponse.onSuccess(HttpStatus.OK, "가게 삭제 완료");
     }
 
@@ -104,10 +105,10 @@ public class StoreController {
             @RequestParam(name = "cursor", required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursor,
             @RequestParam(name = "size", defaultValue = "10") Integer size,
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ) {
         StoreResponseDTO.StoreCursorListResponseDTO response =
-                storeQueryService.getStoresByCategory(categoryId, cursor, size,user);
+                storeQueryService.getStoresByCategory(categoryId, cursor, size,passport);
         return CustomResponse.onSuccess(HttpStatus.OK, response);
     }
 

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/service/command/StoreCommandService.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/service/command/StoreCommandService.java
@@ -1,6 +1,6 @@
 package com.example.cloudfour.storeservice.domain.store.service.command;
 
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import com.example.cloudfour.storeservice.domain.region.entity.Region;
 import com.example.cloudfour.storeservice.domain.region.exception.RegionErrorCode;
 import com.example.cloudfour.storeservice.domain.region.exception.RegionException;
@@ -34,10 +34,10 @@ public class StoreCommandService {
 
     public StoreResponseDTO.StoreCreateResponseDTO createStore(
             StoreRequestDTO.StoreCreateRequestDTO dto,
-            CurrentUser user
+            Passport passport
     ) {
 
-        if(user==null){
+        if(passport==null){
             log.warn("가게 생성 권한 없음");
             throw new StoreException(StoreErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -64,7 +64,7 @@ public class StoreCommandService {
         Store store = StoreConverter.toStore(dto);
         store.setStoreCategory(category);
         store.setRegion(region);
-        store.setOwnerId(user.id());
+        store.setOwnerId(passport.getUserId());
 
         storeRepository.save(store);
         log.info("가게 저장 성공");
@@ -74,7 +74,7 @@ public class StoreCommandService {
     public StoreResponseDTO.StoreUpdateResponseDTO updateStore(
             UUID storeId,
             StoreRequestDTO.StoreUpdateRequestDTO dto,
-            CurrentUser user
+            Passport passport
     ) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() ->{
@@ -82,7 +82,7 @@ public class StoreCommandService {
                     return new StoreException(StoreErrorCode.NOT_FOUND);
                 });
 
-        if (user == null || !store.getOwnerId().equals(user.id())) {
+        if (passport == null || !store.getOwnerId().equals(passport.getUserId())) {
             log.warn("가게 수정 권한 없음");
             throw new StoreException(StoreErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -108,14 +108,14 @@ public class StoreCommandService {
     }
 
     
-    public void deleteStore(UUID storeId, CurrentUser user) {
+    public void deleteStore(UUID storeId, Passport passport) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> {
                     log.warn("존재하지 않는 가게");
                     return new StoreException(StoreErrorCode.NOT_FOUND);
                 });
 
-        if (user==null || !store.getOwnerId().equals(user.id())) {
+        if (passport==null || !store.getOwnerId().equals(passport.getUserId())) {
             log.warn("가게 삭제 권한 없음");
             throw new StoreException(StoreErrorCode.UNAUTHORIZED_ACCESS);
         }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/service/query/StoreQueryService.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/service/query/StoreQueryService.java
@@ -1,6 +1,6 @@
 package com.example.cloudfour.storeservice.domain.store.service.query;
 
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.dto.Passport;
 import com.example.cloudfour.storeservice.domain.collection.document.StoreDocument;
 import com.example.cloudfour.storeservice.domain.collection.repository.query.StoreSearchRepository;
 
@@ -38,13 +38,13 @@ public class StoreQueryService {
     private static final String BASE = "http://user-service/internal/regions";
 
     public StoreResponseDTO.StoreCursorListResponseDTO getAllStores(
-            LocalDateTime cursor, int size, String keyword, CurrentUser user
+            LocalDateTime cursor, int size, String keyword, Passport passport
     ) {
-        if(user==null){
+        if(passport==null){
             log.warn("가게 목록 조회 권한 없음");
             throw new StoreException(StoreErrorCode.UNAUTHORIZED_ACCESS);
         }
-        RegionResponseDTO findRegion =  rt.getForObject(BASE+"/{userId}",RegionResponseDTO.class,user.id());
+        RegionResponseDTO findRegion =  rt.getForObject(BASE+"/{userId}",RegionResponseDTO.class,passport.getUserId());
         if(findRegion == null){
             log.warn("존재하지 않는 지역");
             throw new RegionException(RegionErrorCode.NOT_FOUND);
@@ -67,13 +67,13 @@ public class StoreQueryService {
 
     }
     public StoreResponseDTO.StoreCursorListResponseDTO getStoresByCategory(
-            UUID categoryId, LocalDateTime cursor, int size,CurrentUser user
+            UUID categoryId, LocalDateTime cursor, int size,Passport passport
     ) {
-        if(user==null){
+        if(passport==null){
             log.warn("카테고리 별 가게 목록 조회 권한 없음");
             throw new StoreException(StoreErrorCode.UNAUTHORIZED_ACCESS);
         }
-        RegionResponseDTO findRegion =  rt.getForObject(BASE+"/{userId}",RegionResponseDTO.class,user.id());
+        RegionResponseDTO findRegion =  rt.getForObject(BASE+"/{userId}",RegionResponseDTO.class,passport.getUserId());
         if(findRegion == null){
             log.warn("존재하지 않는 지역");
             throw new RegionException(RegionErrorCode.NOT_FOUND);
@@ -95,8 +95,8 @@ public class StoreQueryService {
         return StoreResponseDTO.StoreCursorListResponseDTO.of(storeList, nextCursor);
     }
 
-    public StoreResponseDTO.StoreDetailResponseDTO getStoreById(UUID storeId,CurrentUser user) {
-        if(user==null){
+    public StoreResponseDTO.StoreDetailResponseDTO getStoreById(UUID storeId,Passport passport) {
+        if(passport==null){
             log.warn("가게 상세 조회 권한 없음");
             throw new StoreException(StoreErrorCode.UNAUTHORIZED_ACCESS);
         }

--- a/store-service/src/main/resources/application.yml
+++ b/store-service/src/main/resources/application.yml
@@ -48,3 +48,6 @@ spring:
   cloud:
     config:
       enabled: false
+
+passport:
+  secret-key: ${PASSPORT_SECRET}

--- a/user-service/src/main/java/com/example/cloudfour/userservice/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/example/cloudfour/userservice/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.example.cloudfour.userservice.config;
 
-import com.example.cloudfour.modulecommon.filter.JwtClaimsAuthFilter;
+import com.example.cloudfour.modulecommon.passport.filter.InternalPassportFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -18,12 +18,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     @Bean
-    JwtClaimsAuthFilter jwtClaimsAuthFilter() {
-        return new JwtClaimsAuthFilter();
+    InternalPassportFilter internalPassportFilter(com.example.cloudfour.modulecommon.util.PassportUtil passportUtil) {
+        return new InternalPassportFilter(passportUtil);
     }
 
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http, JwtClaimsAuthFilter jwtClaimsAuthFilter) throws Exception {
+    SecurityFilterChain securityFilterChain(HttpSecurity http, InternalPassportFilter internalPassportFilter) throws Exception {
         return http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -32,7 +32,7 @@ public class SecurityConfig {
                         .requestMatchers("/users/**", "/profile/**").authenticated()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(jwtClaimsAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(internalPassportFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 

--- a/user-service/src/main/java/com/example/cloudfour/userservice/domain/user/controller/UserController.java
+++ b/user-service/src/main/java/com/example/cloudfour/userservice/domain/user/controller/UserController.java
@@ -1,7 +1,10 @@
 package com.example.cloudfour.userservice.domain.user.controller;
 
 import com.example.cloudfour.modulecommon.apiPayLoad.CustomResponse;
-import com.example.cloudfour.modulecommon.dto.CurrentUser;
+import com.example.cloudfour.modulecommon.passport.annotation.RequireHighAuthLevel;
+import com.example.cloudfour.modulecommon.dto.Passport;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import com.example.cloudfour.userservice.domain.user.dto.UserRequestDTO;
 import com.example.cloudfour.userservice.domain.user.dto.UserResponseDTO;
 import com.example.cloudfour.userservice.domain.user.service.UserAddressService;
@@ -12,8 +15,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -37,67 +38,68 @@ public class UserController {
     private final UserAddressService addressService;
 
     @GetMapping("/me")
-    @PreAuthorize("isAuthenticated() and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER') or hasRole('ROLE_OWNER')")
     @Operation(summary = "내 정보 조회", description = "내 계정의 상세 정보를 조회합니다.")
     public CustomResponse<UserResponseDTO.MeResponseDTO> getMyInfo(
-            @AuthenticationPrincipal CurrentUser user
+            @AuthenticationPrincipal Passport passport
     ) {
-        return CustomResponse.onSuccess(queryService.getMyInfo(user.id()));
+        return CustomResponse.onSuccess(queryService.getMyInfo(passport.getUserId()));
     }
 
     @PatchMapping("/me")
-    @PreAuthorize("isAuthenticated() and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER') or hasRole('ROLE_OWNER')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "내 정보 수정", description = "닉네임/전화번호를 수정합니다.")
     public void updateMyInfo(
-            @AuthenticationPrincipal CurrentUser user,
+            @AuthenticationPrincipal Passport passport,
             @Valid @RequestBody UserRequestDTO.UserUpdateRequestDTO request
     ) {
-        commandService.updateProfile(user.id(), request.nickname(), request.number());
+        commandService.updateProfile(passport.getUserId(), request.nickname(), request.number());
     }
 
     @DeleteMapping("/me")
-    @PreAuthorize("isAuthenticated() and authentication.principal.id == #user.id() or hasRole('ROLE_MASTER')")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER') or hasRole('ROLE_OWNER')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "내 계정 삭제", description = "내 계정을 소프트 삭제합니다.")
-    public void deleteAccount(@AuthenticationPrincipal CurrentUser user) {
-        commandService.deleteAccount(user.id());
+    public void deleteAccount(@AuthenticationPrincipal Passport passport) {
+        commandService.deleteAccount(passport.getUserId());
     }
 
     @PostMapping("/addresses")
-    @PreAuthorize("hasRole('ROLE_CUSTOMER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
+    @RequireHighAuthLevel
     @Operation(summary = "내 주소 등록", description = "내 주소를 등록합니다.")
     public CustomResponse<UserResponseDTO.AddressResponseDTO> addAddress(@Valid @RequestBody UserRequestDTO.AddressRequestDTO request,
-                                                                         @AuthenticationPrincipal CurrentUser user) {
-        UserResponseDTO.AddressResponseDTO address = addressService.addAddress(user.id(), request);
+                                                                         @AuthenticationPrincipal Passport passport) {
+        UserResponseDTO.AddressResponseDTO address = addressService.addAddress(passport.getUserId(), request);
         return CustomResponse.onSuccess(HttpStatus.CREATED, address);
     }
 
     @GetMapping("/addresses")
-    @PreAuthorize("hasRole('ROLE_CUSTOMER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "내 주소 조회", description = "내 주소를 조회합니다.")
     public CustomResponse<List<UserResponseDTO.AddressResponseDTO>> getAddressList(
-            @AuthenticationPrincipal CurrentUser user) {
-        List<UserResponseDTO.AddressResponseDTO> list = addressService.getAddresses(user.id());
+            @AuthenticationPrincipal Passport passport) {
+        List<UserResponseDTO.AddressResponseDTO> list = addressService.getAddresses(passport.getUserId());
         return CustomResponse.onSuccess(list);
     }
 
     @PatchMapping("/addresses/{addressId}")
-    @PreAuthorize("hasRole('ROLE_CUSTOMER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "내 주소 수정", description = "내 주소를 수정합니다.")
     public CustomResponse<UserResponseDTO.AddressResponseDTO> updateAddress(@PathVariable UUID addressId,
                                               @Valid @RequestBody UserRequestDTO.AddressRequestDTO request,
-                                              @AuthenticationPrincipal CurrentUser user) {
-        UserResponseDTO.AddressResponseDTO address = addressService.updateAddress(user.id(), addressId, request);
+                                              @AuthenticationPrincipal Passport passport) {
+        UserResponseDTO.AddressResponseDTO address = addressService.updateAddress(passport.getUserId(), addressId, request);
         return CustomResponse.onSuccess(HttpStatus.OK, address);
     }
 
     @PatchMapping("/addresses/delete/{addressId}")
-    @PreAuthorize("hasRole('ROLE_CUSTOMER') and authentication.principal.id == #user.id()")
+    @PreAuthorize("hasRole('ROLE_CUSTOMER')")
     @Operation(summary = "내 주소 삭제", description = "내 주소를 삭제합니다.")
     public CustomResponse<Void> deleteAddress(@PathVariable UUID addressId,
-                                              @AuthenticationPrincipal CurrentUser user) {
-        addressService.deleteAddress(user.id(), addressId);
+                                              @AuthenticationPrincipal Passport passport) {
+        addressService.deleteAddress(passport.getUserId(), addressId);
         return CustomResponse.onSuccess(null);
     }
 }

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 server:
   port: 8014
 
+logging:
+  level:
+    com.example.cloudfour.modulecommon.util.PassportUtil: DEBUG
+
 eureka:
   instance:
     prefer-ip-address: true
@@ -9,7 +13,7 @@ eureka:
     register-with-eureka: true
     fetch-registry: true
     serviceUrl:
-      defaultZone: http://discovery:8761/eureka/
+      defaultZone: http://localhost:8761/eureka/
 
 spring:
   application:
@@ -60,3 +64,6 @@ spring:
     enable-spring-security: true
     default-consumes-media-type: application/json
     default-produces-media-type: application/json
+
+passport:
+  secret-key: ${PASSPORT_SECRET}


### PR DESCRIPTION
## 🔘Part

- [x] passport 설정
- [x] passport dto
- [x] auth-service passport 발급 구현
- [x] security 등록 token 구현
- [x] 각 서비스 적용

  <br/>
## ➕ 이슈 링크

- #12 

<br/>

## 🔎 작업 내용

- gateway에서 외부 JWT를 검증 후 교환하여 내부 전용 Passport(서비스용 토큰)을 발급해 다운스트림으로 전달
- 각 서비스 passport security 주입
- currentUser -> passport 수정
- 서비스 내부 통신 인증 구현

  <br/>

## 이미지 첨부

<img width="668" height="128" alt="image" src="https://github.com/user-attachments/assets/9a35d155-6427-4159-9b79-0b63a68d8e15" />

passport 환경변수 추가 필요

<img width="1056" height="524" alt="스크린샷 2025-09-08 오후 7 24 34" src="https://github.com/user-attachments/assets/2b16709e-dc92-4a71-a157-abcabdfcd577" />

security context 등록

<img width="855" height="583" alt="스크린샷 2025-09-08 오후 7 27 16" src="https://github.com/user-attachments/assets/7e8c7e9f-0496-4c43-9135-7a3e15579a95" />

apigateway authfilter에서 auth-service로 passport 밢급 요청

<img width="897" height="538" alt="스크린샷 2025-09-08 오후 7 28 15" src="https://github.com/user-attachments/assets/a82aaf6f-8f9e-49d3-88e9-8aa392c36740" />

내부 요청 시, passport전달

<img width="882" height="271" alt="스크린샷 2025-09-08 오후 7 28 51" src="https://github.com/user-attachments/assets/25bbb811-fdad-4272-97f7-32c7b32a690f" />

resttemplate config 내 passportInterceptor 설정 추가

<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 패스포트 기반 내부 인증 도입: 토큰 발급/검증 엔드포인트 추가, 게이트웨이가 요청에 패스포트를 첨부, 내부 서비스 간 자동 전파.
  - 주요 서비스 컨트롤러가 패스포트를 기반으로 동작하도록 업데이트.
  - API 게이트웨이 외부 연동을 위한 OpenFeign 활성화.

- 보안
  - /internal/** 등 내부 경로에 인증 요구 강화.
  - 권한 정책을 역할 중심으로 단순화하고, 고보안 레벨 요구 기능 추가.

- 설정
  - PASSPORT_SECRET 환경변수 사용 설정 추가(각 서비스).
  - JSON 날짜 ISO 형식 직렬화 적용.
  - 내부 호출에 인터셉터/로드밸런싱 구성 반영.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->