### PR TITLE
✨ [FEAT] MongoDB 성능 향상

### DIFF
--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/collection/document/StoreDocument.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/collection/document/StoreDocument.java
@@ -7,6 +7,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
+import org.springframework.data.mongodb.core.index.IndexDirection;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.index.TextIndexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
@@ -18,30 +23,67 @@ import java.util.UUID;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document("store-service")
+@CompoundIndexes({
+        @CompoundIndex(name = "category_region_created_idx", def = "{'storeCategory.id': 1, 'siDo': 1, 'siGunGu': 1, 'createdAt': -1}"),
+        @CompoundIndex(name = "category_created_idx", def = "{'storeCategory.id': 1, 'createdAt': -1}"),
+        @CompoundIndex(name = "region_created_idx", def = "{'siDo': 1, 'siGunGu': 1, 'eupMyeonDong': 1, 'createdAt': -1}"),
+        @CompoundIndex(name = "name_category_created_idx", def = "{'name': 1, 'storeCategory.storeCategoryName': 1, 'createdAt': -1}"),
+        @CompoundIndex(name = "menu_store_idx", def = "{'storeId': 1, 'menus.id': 1}"),
+        @CompoundIndex(name = "menu_category_idx", def = "{'storeId': 1, 'menus.menuCategory.id': 1}"),
+        @CompoundIndex(name = "menu_option_idx", def = "{'menus.id': 1, 'menus.menuOptions.id': 1}")
+})
 public class StoreDocument {
     @Id
     private String id;
 
+    @Indexed(unique = true)
     private UUID storeId;
+
+    @Indexed
     private UUID userId;
 
+    @TextIndexed(weight = 2.0f)
     private String name;
+
+    @Indexed
     private String address;
+
     private String phone;
+
+    @TextIndexed
     private String content;
+
+    @Indexed
     private Integer minPrice;
+
     private Integer deliveryTip;
+
+    @Indexed(direction = IndexDirection.DESCENDING)
     private Float rating;
+
+    @Indexed(direction = IndexDirection.DESCENDING)
     private Integer likeCount;
+
+    @Indexed(direction = IndexDirection.DESCENDING)
     private Integer reviewCount;
+
     private String OperationHours;
     private String closedDays;
+
+    @Indexed
     private String siDo;
+
+    @Indexed
     private String siGunGu;
+
+    @Indexed
     private String eupMyeonDong;
+
     private String pictureURL;
 
+    @Indexed
     private LocalDateTime createdAt;
+
     private StoreDocument.StoreCategory storeCategory;
     private List<StoreDocument.Menu> menus;
     private List<StoreDocument.Review> reviews;

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/collection/repository/query/StoreSearchRepositoryImpl.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/collection/repository/query/StoreSearchRepositoryImpl.java
@@ -7,8 +7,14 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.aggregation.ArrayOperators;
+import org.springframework.data.mongodb.core.aggregation.ComparisonOperators;
+import org.springframework.data.mongodb.core.aggregation.UnsetOperation;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.repository.support.QuerydslRepositorySupport;
@@ -16,7 +22,6 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -36,47 +41,23 @@ public class StoreSearchRepositoryImpl extends QuerydslRepositorySupport impleme
 
     @Override
     public Optional<StoreDocument> findStoreByStoreId(UUID storeId) {
-        StoreDocument store = from(storeDocument)
-                .where(storeDocument.storeId.eq(storeId))
-                .fetchOne();
+        Aggregation aggregation = Aggregation.newAggregation(
+                Aggregation.match(Criteria.where("storeId").is(storeId)),
+                Aggregation.project("id", "storeId", "userId", "name", "address", "phone", "content",
+                                "minPrice", "deliveryTip", "rating", "likeCount", "reviewCount",
+                                "OperationHours", "closedDays", "siDo", "siGunGu", "eupMyeonDong",
+                                "pictureURL", "createdAt", "storeCategory", "menus", "reviews")
+                        .and(ArrayOperators.Filter.filter("menus")
+                                .as("m")
+                                .by(ComparisonOperators.Ne.valueOf("m.menuStatus")
+                                        .notEqualTo(MenuStatus.숨김.name())))
+                        .as("menus"),
+                UnsetOperation.unset("menus.menuOptions")
+        );
 
-        if (store == null) {
-            return Optional.empty();
-        }
-
-        if (store.getMenus() != null) {
-            List<StoreDocument.Menu> visibleMenus = store.getMenus().stream()
-                    .filter(menu -> menu.getMenuStatus() != MenuStatus.숨김)
-                    .collect(Collectors.toList());
-
-            StoreDocument filteredStore = StoreDocument.builder()
-                    .id(store.getId())
-                    .storeId(store.getStoreId())
-                    .userId(store.getUserId())
-                    .name(store.getName())
-                    .address(store.getAddress())
-                    .phone(store.getPhone())
-                    .content(store.getContent())
-                    .minPrice(store.getMinPrice())
-                    .deliveryTip(store.getDeliveryTip())
-                    .rating(store.getRating())
-                    .likeCount(store.getLikeCount())
-                    .reviewCount(store.getReviewCount())
-                    .OperationHours(store.getOperationHours())
-                    .closedDays(store.getClosedDays())
-                    .siDo(store.getSiDo())
-                    .siGunGu(store.getSiGunGu())
-                    .eupMyeonDong(store.getEupMyeonDong())
-                    .pictureURL(store.getPictureURL())
-                    .createdAt(store.getCreatedAt())
-                    .storeCategory(store.getStoreCategory())
-                    .menus(visibleMenus)
-                    .reviews(store.getReviews())
-                    .build();
-
-            return Optional.of(filteredStore);
-        }
-        return Optional.of(store);
+        AggregationResults<StoreDocument> results = mongoTemplate.aggregate(aggregation, "store-service", StoreDocument.class);
+        StoreDocument mapped = results.getUniqueMappedResult();
+        return Optional.ofNullable(mapped);
     }
 
     @Override
@@ -140,22 +121,18 @@ public class StoreSearchRepositoryImpl extends QuerydslRepositorySupport impleme
 
     @Override
     public List<StoreDocument.Menu> findMenuByStoreId(UUID storeId) {
-        Criteria criteria = new Criteria().andOperator(
-                Criteria.where("storeId").is(storeId)
+
+        Aggregation aggregation = Aggregation.newAggregation(
+                Aggregation.match(Criteria.where("storeId").is(storeId)),
+                Aggregation.unwind("menus"),
+                Aggregation.match(Criteria.where("menus.menuStatus").ne(MenuStatus.숨김.name())),
+                Aggregation.replaceRoot("menus")
         );
 
-        Query mongoQuery = new Query(criteria);
-        mongoQuery.fields().include("menus");
+        AggregationResults<StoreDocument.Menu> results = mongoTemplate.aggregate(
+                aggregation, "store-service", StoreDocument.Menu.class);
 
-        StoreDocument storeDocument = mongoTemplate.findOne(mongoQuery, StoreDocument.class);
-
-        if (storeDocument == null || storeDocument.getMenus() == null) {
-            return Collections.emptyList();
-        }
-
-        return storeDocument.getMenus().stream()
-                .filter(menu -> menu.getMenuStatus() != MenuStatus.숨김)
-                .collect(Collectors.toList());
+        return results.getMappedResults();
     }
 
     @Override
@@ -199,22 +176,19 @@ public class StoreSearchRepositoryImpl extends QuerydslRepositorySupport impleme
 
     @Override
     public List<StoreDocument.MenuOption> findMenuOptionByMenuIdOrderByAdditionalPrice(UUID menuId) {
-        Criteria criteria = Criteria.where("menus.id").is(menuId);
-        Query mongoQuery = new Query(criteria);
-        mongoQuery.fields().include("menus.$");
+        Aggregation aggregation = Aggregation.newAggregation(
+                Aggregation.match(Criteria.where("menus.id").is(menuId)),
+                Aggregation.unwind("menus"),
+                Aggregation.match(Criteria.where("menus.id").is(menuId)),
+                Aggregation.unwind("menus.menuOptions"),
+                Aggregation.sort(Sort.by("menus.menuOptions.additionalPrice").ascending()),
+                Aggregation.replaceRoot("menus.menuOptions")
+        );
 
-        StoreDocument result = mongoTemplate.findOne(mongoQuery, StoreDocument.class);
+        AggregationResults<StoreDocument.MenuOption> results = mongoTemplate.aggregate(
+                aggregation, StoreDocument.class, StoreDocument.MenuOption.class);
 
-        if (result != null && result.getMenus() != null && !result.getMenus().isEmpty()) {
-            StoreDocument.Menu menu = result.getMenus().getFirst();
-            if (menu.getMenuOptions() != null) {
-                return menu.getMenuOptions().stream()
-                        .sorted(Comparator.comparing(StoreDocument.MenuOption::getAdditionalPrice))
-                        .collect(Collectors.toList());
-            }
-        }
-
-        return Collections.emptyList();
+        return results.getMappedResults();
     }
 
     @Override

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/converter/MenuConverter.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/converter/MenuConverter.java
@@ -22,9 +22,10 @@ public class MenuConverter {
     }
 
     public static MenuResponseDTO.MenuDetailResponseDTO toMenuDetail1ResponseDTO(Menu menu) {
+        Long quantity = (menu.getStock() != null) ? menu.getStock().getQuantity() : 0L;
         return MenuResponseDTO.MenuDetailResponseDTO.builder()
                 .menuCommonResponseDTO(toMenuCommonResponseDTO(menu))
-                .quantity(menu.getStock().getQuantity())
+                .quantity(quantity)
                 .content(menu.getContent())
                 .createdAt(menu.getCreatedAt())
                 .updatedAt(menu.getUpdatedAt())
@@ -53,6 +54,13 @@ public class MenuConverter {
     public static MenuResponseDTO.MenuListResponseDTO toMenuListResponseDTO(StoreDocument.Menu menu) {
         return MenuResponseDTO.MenuListResponseDTO.builder()
                 .menuCommonResponseDTO(documentToMenuCommonResponseDTO(menu))
+                .createdAt(menu.getCreatedAt())
+                .build();
+    }
+
+    public static MenuResponseDTO.MenuListResponseDTO toMenuListResponseDTO(Menu menu) {
+        return MenuResponseDTO.MenuListResponseDTO.builder()
+                .menuCommonResponseDTO(toMenuCommonResponseDTO(menu))
                 .createdAt(menu.getCreatedAt())
                 .build();
     }
@@ -89,10 +97,12 @@ public class MenuConverter {
 
 
     public static MenuCommonResponseDTO toMenuCommonResponseDTO(Menu menu) {
+        Long quantity = (menu.getStock() != null) ? menu.getStock().getQuantity() : 0L;
         return MenuCommonResponseDTO.builder()
                 .menuId(menu.getId())
                 .name(menu.getName())
                 .price(menu.getPrice())
+                .quantity(quantity)
                 .menuPicture(menu.getMenuPicture())
                 .status(menu.getStatus())
                 .category(menu.getMenuCategory().getCategory())

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/review/dto/ReviewResponseDTO.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/review/dto/ReviewResponseDTO.java
@@ -59,6 +59,14 @@ public class ReviewResponseDTO {
 
     @Getter
     @Builder
+    public static class ReviewDocumentResponseDTO{
+        UUID reviewId;
+        Float score;
+        String content;
+    }
+
+    @Getter
+    @Builder
     public static class ReviewUserListResponseDTO{
         List<ReviewUserResponseDTO> reviews;
         private boolean hasNext;

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/converter/StoreConverter.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/converter/StoreConverter.java
@@ -2,12 +2,16 @@ package com.example.cloudfour.storeservice.domain.store.converter;
 
 import com.example.cloudfour.storeservice.domain.collection.document.StoreDocument;
 import com.example.cloudfour.storeservice.domain.common.StoreCartResponseDTO;
+import com.example.cloudfour.storeservice.domain.menu.dto.MenuResponseDTO;
+import com.example.cloudfour.storeservice.domain.menu.converter.MenuConverter;
+import com.example.cloudfour.storeservice.domain.review.dto.ReviewResponseDTO;
 import com.example.cloudfour.storeservice.domain.store.controller.StoreCommonResponseDTO;
 import com.example.cloudfour.storeservice.domain.store.dto.StoreRequestDTO;
 import com.example.cloudfour.storeservice.domain.store.dto.StoreResponseDTO;
 import com.example.cloudfour.storeservice.domain.store.entity.Store;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 public class StoreConverter {
 
@@ -78,6 +82,8 @@ public class StoreConverter {
                 .storeCommonMainResponseDTO(documentToStoreCommonMainResponseDTO(storeDocument))
                 .storeCommonOptionResponseDTO(documentToStoreCommonOptionResponseDTO(storeDocument))
                 .storeCommonsBaseResponseDTO(documentToStoreCommonBaseResponseDTO(storeDocument))
+                .menuListResponseDTOS(documentToMenuListResponseDTO(storeDocument))
+                .reviewUserResponseDTOS(documentToReviewUserResponseDTO(storeDocument))
                 .build();
     }
 
@@ -137,6 +143,30 @@ public class StoreConverter {
                 .storePicture(storeDocument.getPictureURL())
                 .build();
     }
+
+    public static List<MenuResponseDTO.MenuListResponseDTO> documentToMenuListResponseDTO(StoreDocument storeDocument){
+        if (storeDocument.getMenus() == null) {
+            return java.util.List.of();
+        }
+        return storeDocument.getMenus().stream()
+                .map(MenuConverter::toMenuListResponseDTO)
+                .toList();
+    }
+
+    public static List<ReviewResponseDTO.ReviewDocumentResponseDTO> documentToReviewUserResponseDTO(StoreDocument storeDocument){
+        if (storeDocument.getReviews() == null) {
+            return java.util.List.of();
+        }
+        return storeDocument.getReviews().stream()
+                .filter(Objects::nonNull)
+                .map(r -> ReviewResponseDTO.ReviewDocumentResponseDTO.builder()
+                        .reviewId(r.getId())
+                        .score(r.getScore())
+                        .content(r.getContent())
+                        .build())
+                .toList();
+    }
+
 
     public static StoreCartResponseDTO toFindStoreDTO(Store store){
         return StoreCartResponseDTO.builder()

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/dto/StoreResponseDTO.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/dto/StoreResponseDTO.java
@@ -1,5 +1,7 @@
 package com.example.cloudfour.storeservice.domain.store.dto;
 
+import com.example.cloudfour.storeservice.domain.menu.dto.MenuResponseDTO;
+import com.example.cloudfour.storeservice.domain.review.dto.ReviewResponseDTO;
 import com.example.cloudfour.storeservice.domain.store.controller.StoreCommonResponseDTO;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
@@ -65,5 +67,8 @@ public class StoreResponseDTO {
         StoreCommonResponseDTO.StoreCommonMainResponseDTO storeCommonMainResponseDTO;
         @JsonUnwrapped
         StoreCommonResponseDTO.StoreCommonOptionResponseDTO storeCommonOptionResponseDTO;
+        List<ReviewResponseDTO.ReviewDocumentResponseDTO> reviewUserResponseDTOS;
+        List<MenuResponseDTO.MenuListResponseDTO> menuListResponseDTOS;
+
     }
 }


### PR DESCRIPTION
## 🔘Part

- [x] store 상세 조회 변경
- [x] MongoDB 조회 성능 향상

  <br/>
## ➕ 이슈 링크

- #32 

<br/>

## 🔎 작업 내용

- store 상세 조회에서 review 3개, menu 전체 조회 가능하도록 변경 ( MongoDB 사용 이유였는데 구현 안했었음 )
- storeDocument에 index추가
- store 상세 조회 mongoRepository에서 필요한 데이터만 불러옴

  <br/>

## 이미지 첨부

<br/>
